### PR TITLE
set ingress class annotation on all ingress resources

### DIFF
--- a/pillan/rook-ceph/ceph-dashboard-ingress.yaml
+++ b/pillan/rook-ceph/ceph-dashboard-ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/issuer: letsencrypt
+    kubernetes.io/ingress.class: nginx
 spec:
   tls:
     - hosts:

--- a/pillan/rook-ceph/s3/ingress.yaml
+++ b/pillan/rook-ceph/s3/ingress.yaml
@@ -5,8 +5,8 @@ metadata:
   name: rook-ceph-rgw-ingress
   namespace: rook-ceph
   annotations:
-    cert-manager.io/issuer: "letsencrypt"
-    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/issuer: letsencrypt
+    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
   tls:

--- a/yagan/rook-ceph/ceph-dashboard-ingress.yaml
+++ b/yagan/rook-ceph/ceph-dashboard-ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-staging
+    kubernetes.io/ingress.class: nginx
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
It seems that nginx-ingress 1.1.x has a breaking change in behavior and
will now ignore any ingress resource that doesn't have a class
annotation.