### PR TITLE
(yagan) change rook dash fqdn to rook-ceph.yagan.cp.lsst.org

### DIFF
--- a/yagan/rook-ceph/ceph-dashboard-ingress.yaml
+++ b/yagan/rook-ceph/ceph-dashboard-ingress.yaml
@@ -10,10 +10,10 @@ metadata:
 spec:
   tls:
     - hosts:
-        - rook-ceph.cp.lsst.org
+        - rook-ceph.yagan.cp.lsst.org
       secretName: tls-rook-ceph-ingress
   rules:
-    - host: rook-ceph.cp.lsst.org
+    - host: rook-ceph.yagan.cp.lsst.org
       http:
         paths:
           - path: /


### PR DESCRIPTION
To allow multiple rook dashboard instances under cp.lsst.org.