### PR TITLE
(tu site) chart updates related to k8s 1.23 migration

### DIFF
--- a/pillan/cert-manager/cert-manager.sh
+++ b/pillan/cert-manager/cert-manager.sh
@@ -2,17 +2,19 @@
 
 set -ex
 
+CHART_VERSION="1.9.1"
+
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 kubectl create namespace cert-manager --dry-run -o yaml | kubectl apply -f -
 
 # helm managment of the CRDs did not work when tested
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.1/cert-manager.crds.yaml
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v${CHART_VERSION}/cert-manager.crds.yaml
 
 helm upgrade --install \
   cert-manager jetstack/cert-manager \
   --create-namespace --namespace cert-manager \
-  --version v1.4.0 \
+  --version v${CHART_VERSION} \
   --set installCRDS=false
 
 cat > secret.yaml << END

--- a/pillan/ingress/ingress-nginx-helm.sh
+++ b/pillan/ingress/ingress-nginx-helm.sh
@@ -8,7 +8,7 @@ helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v3.23.0 \
+  --version v4.2.1 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true

--- a/rancher.tu/cert-manager/cert-manager.sh
+++ b/rancher.tu/cert-manager/cert-manager.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CHART_VERSION="1.6.1"
+CHART_VERSION="1.9.1"
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update

--- a/rancher.tu/ingress/ingress-nginx.sh
+++ b/rancher.tu/ingress/ingress-nginx.sh
@@ -8,7 +8,7 @@ helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v3.39.0 \
+  --version v4.2.1 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true

--- a/rancher.tu/rancher/rancher.sh
+++ b/rancher.tu/rancher/rancher.sh
@@ -10,7 +10,7 @@ helm upgrade --install \
   --create-namespace --namespace cattle-system \
   --set hostname=rancher.tu.lsst.org \
   --set ingress.tls.source=secret \
-  --set ingress.extraAnnotations."cert-manager\.io/cluster-issuer"=letsencrypt \
-  --version v2.6.3
+  --version v2.6.6 \
+  -f ./values.yaml
 
 kubectl -n cattle-system rollout status deploy/rancher

--- a/rancher.tu/rancher/values.yaml
+++ b/rancher.tu/rancher/values.yaml
@@ -1,0 +1,5 @@
+---
+ingress:
+  extraAnnotations:
+    "cert-manager.io/cluster-issuer": letsencrypt
+    "kubernetes.io/ingress.class": nginx


### PR DESCRIPTION
Strange issues were observed when restarting k8s in that the ingress
controller would not pass its own http health checks.  Attempting to
reinstall the same version failed to resolve the problem.  Updating to
4.2.1 fixed the issue. The root cause is unknown.