### PR TITLE
add quotas to ceph pools on ruka/pillan/yagan

### DIFF
--- a/pillan/rook-ceph/cephblockpool.yaml
+++ b/pillan/rook-ceph/cephblockpool.yaml
@@ -9,3 +9,5 @@ spec:
   replicated:
     size: 3
     requireSafeReplicaSize: true
+  quotas:
+    maxSize: 3.4Ti

--- a/pillan/rook-ceph/nfs/cephfs-jhome.yaml
+++ b/pillan/rook-ceph/nfs/cephfs-jhome.yaml
@@ -9,10 +9,14 @@ spec:
     failureDomain: host
     replicated:
       size: 3
+    quotas:
+      maxSize: 10Gi
   dataPools:
     - failureDomain: host
       replicated:
         size: 3
+      quotas:
+        maxSize: 250Gi
   metadataServer:
     activeCount: 3
     activeStandby: true

--- a/pillan/rook-ceph/nfs/cephfs-lsstdata.yaml
+++ b/pillan/rook-ceph/nfs/cephfs-lsstdata.yaml
@@ -9,10 +9,14 @@ spec:
     failureDomain: host
     replicated:
       size: 3
+    quotas:
+      maxSize: 10Gi
   dataPools:
     - failureDomain: host
       replicated:
         size: 3
+      quotas:
+        maxSize: 100Gi
   metadataServer:
     activeCount: 3
     activeStandby: true

--- a/pillan/rook-ceph/nfs/cephfs-project.yaml
+++ b/pillan/rook-ceph/nfs/cephfs-project.yaml
@@ -9,10 +9,14 @@ spec:
     failureDomain: host
     replicated:
       size: 3
+    quotas:
+      maxSize: 10Gi
   dataPools:
     - failureDomain: host
       replicated:
         size: 3
+      quotas:
+        maxSize: 500Gi
   metadataServer:
     activeCount: 3
     activeStandby: true

--- a/pillan/rook-ceph/nfs/cephfs-scratch.yaml
+++ b/pillan/rook-ceph/nfs/cephfs-scratch.yaml
@@ -9,10 +9,14 @@ spec:
     failureDomain: host
     replicated:
       size: 3
+    quotas:
+      maxSize: 10Gi
   dataPools:
     - failureDomain: host
       replicated:
         size: 3
+      quotas:
+        maxSize: 2Ti
   metadataServer:
     activeCount: 3
     activeStandby: true

--- a/pillan/rook-ceph/s3/object_store.yaml
+++ b/pillan/rook-ceph/s3/object_store.yaml
@@ -9,11 +9,15 @@ spec:
     failureDomain: host
     replicated:
       size: 3
+    quotas:
+      maxSize: 10Gi
   dataPool:
     failureDomain: host
     erasureCoded:
       dataChunks: 3
       codingChunks: 2
+    quotas:
+      maxSize: 1Ti
   preservePoolsOnDelete: false
   gateway:
     sslCertificateRef:

--- a/ruka/rook-ceph/cephblockpool.yaml
+++ b/ruka/rook-ceph/cephblockpool.yaml
@@ -9,3 +9,5 @@ spec:
   replicated:
     size: 3
     requireSafeReplicaSize: true
+  quotas:
+    maxSize: 2Ti

--- a/ruka/rook-ceph/demo/ceph-demo-pvc.yaml
+++ b/ruka/rook-ceph/demo/ceph-demo-pvc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: ceph-demo-pvc
+  name: ceph-demo-pvc1
 spec:
   storageClassName: rook-ceph-block
   accessModes:

--- a/yagan/rook-ceph/cephblockpool.yaml
+++ b/yagan/rook-ceph/cephblockpool.yaml
@@ -9,3 +9,5 @@ spec:
   replicated:
     size: 3
     requireSafeReplicaSize: true
+  quotas:
+    maxSize: 8Ti


### PR DESCRIPTION
Quotas were already manually set on pillan & yagan and the values have been copied to the ceph CRDs without modification.