### PR TITLE
CloudnativePG manual cronjob for backup

### DIFF
--- a/pillan/cnpg/cnpg-backup.sh
+++ b/pillan/cnpg/cnpg-backup.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+cat << END | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cnpg-backup-secrets
+  namespace: cloudnativepg
+type: Opaque
+stringData:
+    ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+    SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+    password: ${SUPERUSER_PASSWORD}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cnpg-backups
+  namespace: cloudnativepg
+spec:
+  concurrencyPolicy: Forbid
+  schedule: "0 12,21 * * *" #8AM CLT - 5PM CLT
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: cnpg-backup
+            image: docker.io/cbarria/cnpg-backup:0.1
+            imagePullPolicy: IfNotPresent
+            env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: cnpg-backup-secrets
+                  key: ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cnpg-backup-secrets
+                  key: SECRET_ACCESS_KEY
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cnpg-backup-secrets
+                  key: password
+            - name: HOST
+              value: "139.229.134.157"
+          restartPolicy: OnFailure
+END

--- a/pillan/cnpg/cnpg-backup.sh
+++ b/pillan/cnpg/cnpg-backup.sh
@@ -7,9 +7,9 @@ metadata:
   namespace: cloudnativepg
 type: Opaque
 stringData:
-    ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-    SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-    password: ${SUPERUSER_PASSWORD}
+  AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+  AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+  PGPASSWORD: ${SUPERUSER_PASSWORD}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -21,29 +21,19 @@ spec:
   schedule: "0 12,21 * * *" #8AM CLT - 5PM CLT
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 172800
       template:
         spec:
+          activeDeadlineSeconds: 3600
           containers:
           - name: cnpg-backup
             image: docker.io/cbarria/cnpg-backup:0.1
             imagePullPolicy: IfNotPresent
+            envFrom:
+            - secretRef:
+                name: cnpg-backup-secrets
             env:
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: cnpg-backup-secrets
-                  key: ACCESS_KEY_ID
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: cnpg-backup-secrets
-                  key: SECRET_ACCESS_KEY
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: cnpg-backup-secrets
-                  key: password
             - name: HOST
-              value: "139.229.134.157"
+              value: "cnpg-loadbalancer.cloudnativepg.svc.cluster.local"
           restartPolicy: OnFailure
 END

--- a/pillan/cnpg/cnpg.sh
+++ b/pillan/cnpg/cnpg.sh
@@ -57,7 +57,7 @@ metadata:
   namespace: cloudnativepg
 spec:
   instances: 3
-  logLevel: debug
+  #logLevel: debug
   #startDelay: 300
   #stopDelay: 300
 


### PR DESCRIPTION
automatic cnpg backup problems are not solved yet, but this will allow us to "manually" backup the instance with a cronjob while we resolve this issue, also lowered the debug info on the cluster because is not needed in production.