### PR TITLE
Add missing atomic flag to scripts in cookbook

### DIFF
--- a/gaw/ingress/ingress-nginx.sh
+++ b/gaw/ingress/ingress-nginx.sh
@@ -11,4 +11,5 @@ helm upgrade --install \
   --version v4.2.1 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
-  --set rbac.create=true
+  --set rbac.create=true \
+  --atomic

--- a/kueyen/cert-manager/cert-manager.sh
+++ b/kueyen/cert-manager/cert-manager.sh
@@ -15,7 +15,8 @@ helm upgrade --install \
   cert-manager jetstack/cert-manager \
   --create-namespace --namespace cert-manager \
   --version v${CHART_VERSION} \
-  --set installCRDS=false
+  --set installCRDS=false \
+  --atomic
 
 cat > secret.yaml << END
 apiVersion: v1

--- a/kueyen/ingress/ingress-nginx.sh
+++ b/kueyen/ingress/ingress-nginx.sh
@@ -11,4 +11,5 @@ helm upgrade --install \
   --version v4.2.1 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
-  --set rbac.create=true
+  --set rbac.create=true \
+  --atomic

--- a/luan/ingress/ingress-nginx.sh
+++ b/luan/ingress/ingress-nginx.sh
@@ -11,4 +11,5 @@ helm upgrade --install \
   --version v4.2.1 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
-  --set rbac.create=true
+  --set rbac.create=true \
+  --atomic

--- a/pillan/cert-manager/cert-manager.sh
+++ b/pillan/cert-manager/cert-manager.sh
@@ -15,7 +15,8 @@ helm upgrade --install \
   cert-manager jetstack/cert-manager \
   --create-namespace --namespace cert-manager \
   --version v${CHART_VERSION} \
-  --set installCRDS=false
+  --set installCRDS=false \
+  --atomic
 
 cat > secret.yaml << END
 apiVersion: v1

--- a/pillan/ingress/ingress-nginx.sh
+++ b/pillan/ingress/ingress-nginx.sh
@@ -11,4 +11,5 @@ helm upgrade --install \
   --version v4.2.1 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
-  --set rbac.create=true
+  --set rbac.create=true \
+  --atomic

--- a/pillan/prometheus/prometheus.sh
+++ b/pillan/prometheus/prometheus.sh
@@ -9,7 +9,8 @@ helm repo update
 helm upgrade --install \
   kube-prometheus-stack prometheus-community/kube-prometheus-stack \
   --create-namespace --namespace kube-prometheus-stack \
-  -f ./values.yaml
+  -f ./values.yaml \
+  --atomic
 
 # sanity check
 kubectl --namespace kube-prometheus-stack get pods -l "release=kube-prometheus-stack"

--- a/rancher.ls/cert-manager/cert-manager.sh
+++ b/rancher.ls/cert-manager/cert-manager.sh
@@ -15,7 +15,8 @@ helm upgrade --install \
   cert-manager jetstack/cert-manager \
   --create-namespace --namespace cert-manager \
   --version v${CHART_VERSION} \
-  --set installCRDS=false
+  --set installCRDS=false \
+  --atomic
 
 cat > secret.yaml << END
 apiVersion: v1

--- a/rancher.ls/ingress/ingress-nginx.sh
+++ b/rancher.ls/ingress/ingress-nginx.sh
@@ -11,4 +11,5 @@ helm upgrade --install \
   --version v4.2.1 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
-  --set rbac.create=true
+  --set rbac.create=true \
+  --atomic

--- a/rancher.tu/cert-manager/cert-manager.sh
+++ b/rancher.tu/cert-manager/cert-manager.sh
@@ -15,7 +15,8 @@ helm upgrade --install \
   cert-manager jetstack/cert-manager \
   --create-namespace --namespace cert-manager \
   --version v${CHART_VERSION} \
-  --set installCRDS=false
+  --set installCRDS=false \
+  --atomic
 
 cat > secret.yaml << END
 apiVersion: v1

--- a/rancher.tu/ingress/ingress-nginx.sh
+++ b/rancher.tu/ingress/ingress-nginx.sh
@@ -11,4 +11,5 @@ helm upgrade --install \
   --version v4.2.1 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
-  --set rbac.create=true
+  --set rbac.create=true \
+  --atomic

--- a/ruka/cert-manager/cert-manager.sh
+++ b/ruka/cert-manager/cert-manager.sh
@@ -15,7 +15,8 @@ helm upgrade --install \
   cert-manager jetstack/cert-manager \
   --create-namespace --namespace cert-manager \
   --version v${CHART_VERSION} \
-  --set installCRDS=false
+  --set installCRDS=false \
+  --atomic
 
 cat > secret.yaml << END
 apiVersion: v1

--- a/ruka/ingress/ingress-nginx.sh
+++ b/ruka/ingress/ingress-nginx.sh
@@ -11,4 +11,5 @@ helm upgrade --install \
   --version v4.2.1 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
-  --set rbac.create=true
+  --set rbac.create=true \
+  --atomic

--- a/yagan/ingress/ingress-nginx.sh
+++ b/yagan/ingress/ingress-nginx.sh
@@ -11,4 +11,5 @@ helm upgrade --install \
   --version v3.23.0 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
-  --set rbac.create=true
+  --set rbac.create=true \
+  --atomic


### PR DESCRIPTION
As per requested in ticket IT-3935 some scripts in the cookbook needed the atomic flag in case the upgrade/install failed.
here is the list of scripts missing the flag :
./yagan/ingress/ingress-nginx.sh
./ruka/ingress/ingress-nginx.sh
./ruka/cert-manager/cert-manager.sh
./pillan/ingress/ingress-nginx.sh
./pillan/cert-manager/cert-manager.sh
./pillan/prometheus/prometheus.sh
./gaw/ingress/ingress-nginx.sh
./luan/ingress/ingress-nginx.sh
./rancher.tu/ingress/ingress-nginx.sh
./rancher.tu/cert-manager/cert-manager.sh
./kueyen/ingress/ingress-nginx.sh
./kueyen/cert-manager/cert-manager.sh
./rancher.ls/ingress/ingress-nginx.sh
./rancher.ls/cert-manager/cert-manager.sh