### PR TITLE
CloudnativePG Manual Backup improvements

### DIFF
--- a/ruka/cnpg/cnpg-backup.sh
+++ b/ruka/cnpg/cnpg-backup.sh
@@ -29,14 +29,9 @@ spec:
           containers:
           - name: cnpg-backup
             image: docker.io/cbarria/cnpg-backup:0.3
-            resources:
-              requests:
-                ephemeral-storage: "6Gi"
-              limits:
-                ephemeral-storage: "8Gi"
             volumeMounts:
-              - name: ephemeral
-                mountPath: "/tmp"
+            - name: ephemeral
+              mountPath: "/tmp"  
             imagePullPolicy: IfNotPresent
             envFrom:
             - secretRef:
@@ -44,5 +39,14 @@ spec:
             env:
             - name: HOST
               value: "cnpg-loadbalancer.cloudnativepg.svc.cluster.local"
+          volumes:
+            - name: ephemeral
+              ephemeral:
+                volumeClaimTemplate:
+                  spec:
+                    accessModes: [ "ReadWriteOnce" ]
+                    resources:
+                      requests:
+                        storage: 5Gi
           restartPolicy: OnFailure
 END

--- a/ruka/cnpg/cnpg-backup.sh
+++ b/ruka/cnpg/cnpg-backup.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+cat << END | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cnpg-backup-secrets
+  namespace: cloudnativepg
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+  AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+  AWS_ACCESS_BUCKET: ${AWS_ACCESS_BUCKET}
+  PGPASSWORD: ${SUPERUSER_PASSWORD}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cnpg-backups
+  namespace: cloudnativepg
+spec:
+  concurrencyPolicy: Forbid
+  schedule: "0 12,21 * * *" #9AM CLT - 6PM CLT
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 172800
+      template:
+        spec:
+          activeDeadlineSeconds: 3600
+          containers:
+          - name: cnpg-backup
+            image: docker.io/cbarria/cnpg-backup:0.3
+            resources:
+              requests:
+                ephemeral-storage: "6Gi"
+              limits:
+                ephemeral-storage: "8Gi"
+            volumeMounts:
+              - name: ephemeral
+                mountPath: "/tmp"
+            imagePullPolicy: IfNotPresent
+            envFrom:
+            - secretRef:
+                name: cnpg-backup-secrets
+            env:
+            - name: HOST
+              value: "cnpg-loadbalancer.cloudnativepg.svc.cluster.local"
+          restartPolicy: OnFailure
+END

--- a/ruka/cnpg/cnpg.sh
+++ b/ruka/cnpg/cnpg.sh
@@ -5,7 +5,7 @@ set -xe
 # Install cloudnativePG on cluster
 helm repo add cnpg https://cloudnative-pg.github.io/charts
 helm upgrade --install cnpg \
-  --version="0.14.0" \
+  --version="0.15.0" \
   --namespace cnpg-system \
   --create-namespace \
   cnpg/cloudnative-pg \
@@ -57,7 +57,7 @@ metadata:
   namespace: cloudnativepg
 spec:
   instances: 3
-  logLevel: debug
+  #logLevel: debug
   #startDelay: 300
   #stopDelay: 300
 
@@ -77,20 +77,20 @@ spec:
       secret:
         name: cnpg-cluster-app-user
 
-  backup:
-    barmanObjectStore:
-      destinationPath: ${AWS_ACCESS_BUCKET}
-      s3Credentials:
-        accessKeyId:
-          name: cnpg-aws-creds
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: cnpg-aws-creds
-          key: ACCESS_SECRET_KEY
-      wal:
-          compression: gzip
-
-    retentionPolicy: "90d"
+#  backup:
+#    barmanObjectStore:
+#      destinationPath: ${AWS_ACCESS_BUCKET}
+#      s3Credentials:
+#        accessKeyId:
+#          name: cnpg-aws-creds
+#          key: ACCESS_KEY_ID
+#        secretAccessKey:
+#          name: cnpg-aws-creds
+#          key: ACCESS_SECRET_KEY
+#      wal:
+#          compression: gzip
+#
+#    retentionPolicy: "90d"
 
   superuserSecret:
     name: cnpg-cluster-superuser
@@ -98,7 +98,7 @@ spec:
 # Resources and Storage Needs to be Adjust!
 
   storage:
-    size: 10Gi
+    size: 5Gi
 
   monitoring:
     enablePodMonitor: true


### PR DESCRIPTION
- Adds 60 Days Lifecycle on AWS S3 Storage. (vs Lifecycle on AWS which is paid)
- Adds 5Gi as Ephemeral Storage to avoid running out of space while backing data up.
- Stop logging, bump Helm Chart version to 0.15.0 (which has v1.17.1 of cnpg), disable native backup (commented)