### PR TITLE
(manke) Ceph dashboard ingress standalone

### DIFF
--- a/manke/rook-ceph/rook-ceph-ingress-dashboard.yaml
+++ b/manke/rook-ceph/rook-ceph-ingress-dashboard.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: rook-ceph-mgr-dashboard
+  namespace: rook-ceph
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      proxy_ssl_verify off;
+spec:
+  tls:
+    - hosts:
+        - ceph.manke.ls.lsst.org
+      secretName: ingress-cert-ceph
+  rules:
+    - host: ceph.manke.ls.lsst.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: rook-ceph-mgr-dashboard
+                port:
+                  name: http-dashboard


### PR DESCRIPTION
This adds an standalone yaml file for the rook-ceph ingress in case the ArgoCD deployment erases it.