### PR TITLE
Metallb 0.13.9 version Bump

### DIFF
--- a/chonchon/metallb/metallb.sh
+++ b/chonchon/metallb/metallb.sh
@@ -5,5 +5,5 @@ helm repo add metallb https://metallb.github.io/metallb
 helm upgrade --install --namespace metallb-system \
      --create-namespace \
     metallb metallb/metallb \
-    --atomic --version 0.13.7
+    --atomic --version 0.13.9
 kubectl apply -f ippool.yaml

--- a/gaw/metallb/metallb.sh
+++ b/gaw/metallb/metallb.sh
@@ -5,5 +5,5 @@ helm repo add metallb https://metallb.github.io/metallb
 helm upgrade --install --namespace metallb-system \
      --create-namespace \
     metallb metallb/metallb \
-    --atomic --version 0.13.7
+    --atomic --version 0.13.9
 kubectl apply -f ippool.yaml

--- a/kueyen/metallb/metallb.sh
+++ b/kueyen/metallb/metallb.sh
@@ -5,5 +5,5 @@ helm repo add metallb https://metallb.github.io/metallb
 helm upgrade --install --namespace metallb-system \
     --create-namespace \
     metallb metallb/metallb \
-    --atomic --version 0.13.7
+    --atomic --version 0.13.9
 kubectl apply -f ippool.yaml

--- a/luan/metallb/metallb.sh
+++ b/luan/metallb/metallb.sh
@@ -5,5 +5,5 @@ helm repo add metallb https://metallb.github.io/metallb
 helm upgrade --install --namespace metallb-system \
     --create-namespace \
     metallb metallb/metallb \
-    --atomic --version 0.13.7
+    --atomic --version 0.13.9
 kubectl apply -f ippool.yaml

--- a/lukay/metallb/metallb.sh
+++ b/lukay/metallb/metallb.sh
@@ -5,5 +5,5 @@ helm repo add metallb https://metallb.github.io/metallb
 helm upgrade --install --namespace metallb-system \
     --create-namespace \
     metallb metallb/metallb \
-    --atomic --version 0.13.7
+    --atomic --version 0.13.9
 kubectl apply -f ippool.yaml

--- a/manke/metallb/metallb.sh
+++ b/manke/metallb/metallb.sh
@@ -5,5 +5,5 @@ helm repo add metallb https://metallb.github.io/metallb
 helm upgrade --install --namespace metallb-system \
     --create-namespace \
     metallb metallb/metallb \
-    --atomic --version 0.13.7
+    --atomic --version 0.13.9
 kubectl apply -f ippool.yaml

--- a/pillan/metallb/metallb.sh
+++ b/pillan/metallb/metallb.sh
@@ -5,5 +5,5 @@ helm repo add metallb https://metallb.github.io/metallb
 helm upgrade --install --namespace metallb-system \
     --create-namespace \
     metallb metallb/metallb \
-    --atomic --version 0.13.7
+    --atomic --version 0.13.9
 kubectl apply -f ippool.yaml

--- a/rancher.cp/metallb/metallb.sh
+++ b/rancher.cp/metallb/metallb.sh
@@ -5,5 +5,5 @@ helm repo add metallb https://metallb.github.io/metallb
 helm upgrade --install --namespace metallb-system \
     --create-namespace \
     metallb metallb/metallb \
-    --atomic --version 0.13.7
+    --atomic --version 0.13.9
 kubectl apply -f ippool.yaml

--- a/rancher.ls/metallb/metallb.sh
+++ b/rancher.ls/metallb/metallb.sh
@@ -5,5 +5,5 @@ helm repo add metallb https://metallb.github.io/metallb
 helm upgrade --install --namespace metallb-system \
     --create-namespace \
     metallb metallb/metallb \
-    --atomic --version 0.13.7
+    --atomic --version 0.13.9
 kubectl apply -f ippool.yaml

--- a/rancher.tu/metallb/metallb.sh
+++ b/rancher.tu/metallb/metallb.sh
@@ -5,5 +5,5 @@ helm repo add metallb https://metallb.github.io/metallb
 helm upgrade --install --namespace metallb-system \
     --create-namespace \
     metallb metallb/metallb \
-    --atomic --version 0.13.7
+    --atomic --version 0.13.9
 kubectl apply -f ippool.yaml

--- a/ruka/metallb/metallb.sh
+++ b/ruka/metallb/metallb.sh
@@ -5,5 +5,5 @@ helm repo add metallb https://metallb.github.io/metallb
 helm upgrade --install --namespace metallb-system \
     --create-namespace \
     metallb metallb/metallb \
-    --atomic --version 0.13.7
+    --atomic --version 0.13.9
 kubectl apply -f ippool.yaml

--- a/yagan/metallb/metallb.sh
+++ b/yagan/metallb/metallb.sh
@@ -5,5 +5,5 @@ helm repo add metallb https://metallb.github.io/metallb
 helm upgrade --install --namespace metallb-system \
     --create-namespace \
     metallb metallb/metallb \
-    --atomic --version 0.13.7
+    --atomic --version 0.13.9
 kubectl apply -f ippool.yaml

--- a/yepun/metallb/metallb.sh
+++ b/yepun/metallb/metallb.sh
@@ -5,5 +5,5 @@ helm repo add metallb https://metallb.github.io/metallb
 helm upgrade --install --namespace metallb-system \
     --create-namespace \
     metallb metallb/metallb \
-    --atomic --version 0.13.7
+    --atomic --version 0.13.9
 kubectl apply -f ippool.yaml


### PR DESCRIPTION
Josh found that metallb version 0.13.7 was suddenly stop working after a few hours on the LHN link project, by updating to version 0.13.9, all clusters have been stable.