### PR TITLE
(ruka) Add LHN ingress controller for rook-ceph

### DIFF
--- a/ruka/ingress/lhn/ingress-nginx-lhn.sh
+++ b/ruka/ingress/lhn/ingress-nginx-lhn.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -ex
+
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
+
+helm upgrade --install \
+  ingress-nginx-lhn ingress-nginx/ingress-nginx \
+  --create-namespace --namespace ingress-nginx-lhn \
+  --set controller.ingressClass="nginx-lhn" \
+  --set controller.ingressClassResource.name="nginx-lhn" \
+  --set controller.service.annotations."metallb\.universe\.tf\/address-pool"=lhn \
+  --version v4.2.1 \
+  --set controller.kind=DaemonSet \
+  --set defaultBackend.replicaCount=3 \
+  --set rbac.create=true \
+  --atomic
+
+kubectl apply -f ingress-s3-lhn.yaml

--- a/ruka/ingress/lhn/ingress-s3-lhn.yaml
+++ b/ruka/ingress/lhn/ingress-s3-lhn.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    kubernetes.io/ingress.class: nginx-lhn
+  name: rook-ceph-rgw-ingress-lhn
+  namespace: rook-ceph
+spec:
+  rules:
+  - host: s3-lhn.ruka.dev.lsst.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: rook-ceph-rgw-lfa
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - s3-lhn.ruka.dev.lsst.org
+    secretName: rook-ceph-rgw-ingress-lhn-tls


### PR DESCRIPTION
This adds a second ingress controller and add the ingress for the s3 on rook as part of the test we did to implement this into chonchon.