### PR TITLE
(ruka) rke bump k8s to v1.25.9-rancher2-2

### DIFF
--- a/ruka/rke/cluster.yml
+++ b/ruka/rke/cluster.yml
@@ -133,7 +133,7 @@ authorization:
   mode: rbac
   options: {}
 ignore_docker_version: false
-kubernetes_version: "v1.23.7-rancher1-1"
+kubernetes_version: "v1.25.9-rancher2-2"
 private_registries: []
 ingress:
   provider: none


### PR DESCRIPTION
This upgrades the version of k8s on ruka to 1.25.9 