### PR TITLE
(Yagan) Add cnpg replication to USDF

### DIFF
--- a/yagan/cnpg/cnpg-replica-lb.yaml
+++ b/yagan/cnpg/cnpg-replica-lb.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    metallb.universe.tf/address-pool: lhn
+  labels:
+    cnpg.io/cluster: cnpg-cluster
+  name: cnpg-loadbalancer-lhn
+  namespace: cloudnativepg
+spec:
+  allocateLoadBalancerNodePorts: true
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - port: 5432
+    protocol: TCP
+    targetPort: 5432
+  selector:
+    postgresql: cnpg-cluster
+    role: primary
+  sessionAffinity: None
+  type: LoadBalancer

--- a/yagan/cnpg/cnpg.sh
+++ b/yagan/cnpg/cnpg.sh
@@ -65,6 +65,7 @@ spec:
       shared_buffers: 256MB
       idle_session_timeout: 4h
     pg_hba:
+      - host replication replicauser all md5
       - host all all 139.229.134.0/23 md5
       - host all all 139.229.136.0/21 md5
       - host all all 139.229.144.0/20 md5
@@ -90,3 +91,4 @@ spec:
 END
 kubectl apply -f deploy.yaml
 kubectl apply -f cnpg-loadbalancer.yaml
+kubectl apply -f cnpg-replica-lb.yaml


### PR DESCRIPTION
This add the replication config in the ```pg_hba``` to the user ```replicauser``` and applies a new service using the Metallb annotation to grab an IP from the pool exposed to the USDF.