### PR TITLE
(pillan) add metallb "general" pool; add auxtel nfs export; pin nfs svc IPs

### DIFF
--- a/pillan/ingress/ingress-nginx.sh
+++ b/pillan/ingress/ingress-nginx.sh
@@ -10,6 +10,7 @@ helm upgrade --install \
   --create-namespace --namespace ingress-nginx \
   --version v4.2.1 \
   --set controller.kind=DaemonSet \
+  --set controller.service.annotations."metallb\.universe\.tf\/loadBalancerIPs"=140.252.146.50 \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true \
   --atomic

--- a/pillan/metallb/demo/metallb-demo-general.yaml
+++ b/pillan/metallb/demo/metallb-demo-general.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-demo-general
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    metallb.universe.tf/address-pool: general
+  name: nginx-svc-general
+  namespace: metallb-demo-general
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http-web-svc
+  selector:
+    app.kubernetes.io/name: proxy
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/name: proxy
+  name: nginx
+  namespace: metallb-demo-general
+spec:
+  containers:
+  - image: nginx:stable
+    name: nginx
+    ports:
+    - containerPort: 80
+      name: http-web-svc
+      protocol: TCP

--- a/pillan/metallb/ippool.yaml
+++ b/pillan/metallb/ippool.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   addresses:
   - 140.252.146.46-140.252.146.59
+  autoAssign: false
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
@@ -16,3 +17,26 @@ metadata:
 spec:
   ipAddressPools:
   - one-pool
+  interfaces:
+  - bond0
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: general
+  namespace: metallb-system
+spec:
+  addresses:
+  - 140.252.147.196-140.252.147.222  # ~140.252.147.192/27
+  autoAssign: true
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: general
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - generic
+  interfaces:
+  - br3035

--- a/pillan/rook-ceph/nfs/cephfs-auxtel.yaml
+++ b/pillan/rook-ceph/nfs/cephfs-auxtel.yaml
@@ -54,7 +54,7 @@ metadata:
   name: rook-ceph-nfs-auxtel
   namespace: rook-ceph
   annotations:
-    metallb.universe.tf/loadBalancerIPs: 140.252.146.55
+    metallb.universe.tf/loadBalancerIPs: 140.252.147.196
 spec:
   ports:
     - name: nfs

--- a/pillan/rook-ceph/nfs/cephfs-auxtel.yaml
+++ b/pillan/rook-ceph/nfs/cephfs-auxtel.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephFilesystem
+metadata:
+  name: auxtel
+  namespace: rook-ceph
+spec:
+  metadataPool:
+    failureDomain: host
+    replicated:
+      size: 3
+    quotas:
+      maxSize: 10Gi
+  dataPools:
+    - failureDomain: host
+      replicated:
+        size: 3
+      quotas:
+        maxSize: 2Ti
+  metadataServer:
+    activeCount: 3
+    activeStandby: true
+  preserveFilesystemOnDelete: false
+---
+apiVersion: ceph.rook.io/v1
+kind: CephNFS
+metadata:
+  name: auxtel
+  namespace: rook-ceph
+spec:
+  rados:
+    pool: auxtel-data0
+    # RADOS namespace where NFS client recovery data is stored in the pool.
+    namespace: nfs-ns
+  server:
+    active: 1
+    resources:
+      limits:
+        cpu: "1.5"
+        memory: 2Gi
+      requests:
+        cpu: "1.5"
+        memory: 2Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: rook-ceph-nfs
+    ceph_daemon_type: nfs
+    ceph_nfs: auxtel
+    instance: a
+    rook_cluster: rook-ceph
+  name: rook-ceph-nfs-auxtel
+  namespace: rook-ceph
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 140.252.146.55
+spec:
+  ports:
+    - name: nfs
+      port: 2049
+      protocol: TCP
+      targetPort: 2049
+  selector:
+    app: rook-ceph-nfs
+    ceph_daemon_type: nfs
+    ceph_nfs: auxtel
+    instance: a
+    rook_cluster: rook-ceph
+  type: LoadBalancer

--- a/pillan/rook-ceph/nfs/cephfs-jhome.yaml
+++ b/pillan/rook-ceph/nfs/cephfs-jhome.yaml
@@ -53,6 +53,8 @@ metadata:
     rook_cluster: rook-ceph
   name: rook-ceph-nfs-jhome
   namespace: rook-ceph
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 140.252.146.51
 spec:
   ports:
     - name: nfs

--- a/pillan/rook-ceph/nfs/cephfs-lsstdata.yaml
+++ b/pillan/rook-ceph/nfs/cephfs-lsstdata.yaml
@@ -53,6 +53,8 @@ metadata:
     rook_cluster: rook-ceph
   name: rook-ceph-nfs-lsstdata
   namespace: rook-ceph
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 140.252.146.52
 spec:
   ports:
     - name: nfs

--- a/pillan/rook-ceph/nfs/cephfs-obsenv.yaml
+++ b/pillan/rook-ceph/nfs/cephfs-obsenv.yaml
@@ -53,6 +53,8 @@ metadata:
     rook_cluster: rook-ceph
   name: rook-ceph-nfs-obs-env
   namespace: rook-ceph
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 140.252.146.57
 spec:
   ports:
     - name: nfs

--- a/pillan/rook-ceph/nfs/cephfs-project.yaml
+++ b/pillan/rook-ceph/nfs/cephfs-project.yaml
@@ -53,6 +53,8 @@ metadata:
     rook_cluster: rook-ceph
   name: rook-ceph-nfs-project
   namespace: rook-ceph
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 140.252.146.53
 spec:
   ports:
     - name: nfs

--- a/pillan/rook-ceph/nfs/cephfs-scratch.yaml
+++ b/pillan/rook-ceph/nfs/cephfs-scratch.yaml
@@ -53,6 +53,8 @@ metadata:
     rook_cluster: rook-ceph
   name: rook-ceph-nfs-scratch
   namespace: rook-ceph
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 140.252.146.54
 spec:
   ports:
     - name: nfs

--- a/pillan/rook-ceph/rook-ceph.sh
+++ b/pillan/rook-ceph/rook-ceph.sh
@@ -49,17 +49,29 @@ ceph() {
   cephtoolbox ceph "$@"
 }
 
-waitfor() {
+# run command until it exits 0
+waitforcmd() {
+  xtrace=$(set +o|grep xtrace); set +x
+  local wait=${1?sleep interval}; shift
+
+  echo "Waiting for $*"
+
+  until "$@" > /dev/null 2>&1; do
+    echo "Waiting for $*"
+    sleep "$wait";
+  done
+
+  eval "$xtrace"
+}
+
+waitforkube() {
   xtrace=$(set +o|grep xtrace); set +x
   local ns=${1?namespace is required}; shift
   local type=${1?type is required}; shift
 
-  echo "Waiting for $type $*"
   # wait for resource to exist. See: https://github.com/kubernetes/kubernetes/issues/83242
-  until kubectl -n "$ns" get "$type" "$@" -o=jsonpath='{.items[0].metadata.name}' >/dev/null 2>&1; do
-    echo "Waiting for $type $*"
-    sleep 1
-  done
+  waitforcmd 2 kubectl -n "$ns" get "$type" "$@" -o=jsonpath='{.items[0].metadata.name}'
+
   eval "$xtrace"
 }
 
@@ -68,10 +80,22 @@ waitforpod() {
   local ns=${1?namespace is required}; shift
 
   # wait for pod to exist
-  waitfor "$ns" pod "$@"
+  waitforkube "$ns" pod "$@"
 
   # wait for pod to be ready
   kubectl -n rook-ceph wait --for=condition=ready --timeout=180s pod "$@"
+  eval "$xtrace"
+}
+
+# wait for ceph nfs related resources to be ready
+waitfornfs() {
+  xtrace=$(set +o|grep xtrace); set +x
+  local fs=${1?fs name}; shift
+
+  waitforpod rook-ceph -l app=rook-ceph-nfs,ceph_nfs="$fs"
+  waitforpod rook-ceph -l app=rook-ceph-mds,rook_file_system="$fs"
+  waitforcmd 2 ceph fs get "$fs"
+
   eval "$xtrace"
 }
 
@@ -99,7 +123,7 @@ helm upgrade --install \
   --version "v${VERSION}" \
   -f ./rook-ceph-cluster-values.yaml
 
-waitfor rook-ceph secret rook-ceph-dashboard-password
+waitforkube rook-ceph secret rook-ceph-dashboard-password
 set +x
 echo "===================="
 echo "dashboard passphrase"
@@ -108,14 +132,12 @@ kubectl -n rook-ceph get secret rook-ceph-dashboard-password -o jsonpath="{['dat
 echo "===================="
 set -x
 
-# enable ceph orchestrator for nfs
-# as of 1.9.9, this is needed to enable configuration of nfs exports via both
-# the dashboard and the cli
-# https://rook.io/docs/rook/v1.9/CRDs/ceph-nfs-crd/?h=nfs#enable-the-ceph-orchestrator-if-necessary
+# disable ceph rook orechestrator for >= 17.2.1 and >= 16.2.11
+# https://rook.io/docs/rook/latest/CRDs/ceph-nfs-crd/#ceph-v1721
 waitforpod rook-ceph -l app=rook-ceph-tools
-ceph mgr module enable rook
 ceph mgr module enable nfs
-ceph orch set backend rook
+ceph orch set backend ""
+ceph mgr module disable rook
 
 # --- customize below this line ---
 
@@ -134,25 +156,24 @@ kubectl apply -f nfs/cephfs-obsenv.yaml
 kubectl apply -f s3/object_store.yaml
 kubectl apply -f s3/ingress.yaml
 
-# Use output and add it at the Ceph FS Path
+waitfornfs jhome
 ceph nfs export rm jhome /jhome
-waitforpod rook-ceph -l app=rook-ceph-nfs,ceph_nfs=jhome
 ceph nfs export create cephfs jhome /jhome jhome /jhome
 
+waitfornfs lsstdata
 ceph nfs export rm lsstdata /lsstdata
-waitforpod rook-ceph -l app=rook-ceph-nfs,ceph_nfs=lsstdata
 ceph nfs export create cephfs lsstdata /lsstdata lsstdata # no /lsstdata relative export
 
+waitfornfs project
 ceph nfs export rm project /project
-waitforpod rook-ceph -l app=rook-ceph-nfs,ceph_nfs=project
 ceph nfs export create cephfs project /project project /project
 
+waitfornfs scratch
 ceph nfs export rm scratch /scratch
-waitforpod rook-ceph -l app=rook-ceph-nfs,ceph_nfs=scratch
 ceph nfs export create cephfs scratch /scratch scratch /scratch
 
+waitfornfs obs-env
 ceph nfs export rm obs-env /obs-env
-waitforpod rook-ceph -l app=rook-ceph-nfs,ceph_nfs=obs-env
 ceph nfs export create cephfs obs-env /obs-env obs-env
 
 # vim: tabstop=2 shiftwidth=2 expandtab

--- a/pillan/rook-ceph/rook-ceph.sh
+++ b/pillan/rook-ceph/rook-ceph.sh
@@ -151,6 +151,7 @@ kubectl apply -f nfs/cephfs-lsstdata.yaml
 kubectl apply -f nfs/cephfs-project.yaml
 kubectl apply -f nfs/cephfs-scratch.yaml
 kubectl apply -f nfs/cephfs-obsenv.yaml
+kubectl apply -f nfs/cephfs-auxtel.yaml
 
 # lfa/s3
 kubectl apply -f s3/object_store.yaml
@@ -175,5 +176,9 @@ ceph nfs export create cephfs scratch /scratch scratch /scratch
 waitfornfs obs-env
 ceph nfs export rm obs-env /obs-env
 ceph nfs export create cephfs obs-env /obs-env obs-env
+
+waitfornfs auxtel
+ceph nfs export rm auxtel /auxtel
+ceph nfs export create cephfs auxtel /auxtel auxtel
 
 # vim: tabstop=2 shiftwidth=2 expandtab


### PR DESCRIPTION
The current metallb pool on pillan is full and can't be expanded as the subnet is also full. A new /27 has been allocated to be the new default pool while leaving the existing pool in place.

This is not a complete solution as new routes will also be needed to make this work but can't be applied as this time due to release testing on pillan.