### PR TITLE
cert-manager and ingress-nginx version upgrade

### DIFF
--- a/chonchon/cert-manager/cert-manager.sh
+++ b/chonchon/cert-manager/cert-manager.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CHART_VERSION="1.9.1"
+CHART_VERSION="1.12.2"
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update

--- a/chonchon/ingress/ingress-nginx.sh
+++ b/chonchon/ingress/ingress-nginx.sh
@@ -9,7 +9,7 @@ helm upgrade --install \
   --atomic \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v4.2.1 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true

--- a/chonchon/ingress/lhn/ingress-nginx-lhn.sh
+++ b/chonchon/ingress/lhn/ingress-nginx-lhn.sh
@@ -11,7 +11,7 @@ helm upgrade --install \
   --set controller.ingressClass="nginx-lhn" \
   --set controller.ingressClassResource.name="nginx-lhn" \
   --set controller.service.annotations."metallb\.universe\.tf\/address-pool"=lhn \
-  --version v4.2.1 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true \

--- a/gaw/cert-manager/cert-manager.sh
+++ b/gaw/cert-manager/cert-manager.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CHART_VERSION="1.9.1"
+CHART_VERSION="1.12.2"
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update

--- a/gaw/ingress/ingress-nginx.sh
+++ b/gaw/ingress/ingress-nginx.sh
@@ -8,7 +8,7 @@ helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v4.2.1 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true \

--- a/konkong/cert-manager/cert-manager.sh
+++ b/konkong/cert-manager/cert-manager.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CHART_VERSION="1.9.1"
+CHART_VERSION="1.12.2"
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update

--- a/konkong/ingress/ingress-nginx.sh
+++ b/konkong/ingress/ingress-nginx.sh
@@ -8,7 +8,7 @@ helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v4.2.1 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true \

--- a/kueyen/cert-manager/cert-manager.sh
+++ b/kueyen/cert-manager/cert-manager.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CHART_VERSION="1.9.1"
+CHART_VERSION="1.12.2"
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update

--- a/kueyen/ingress/ingress-nginx.sh
+++ b/kueyen/ingress/ingress-nginx.sh
@@ -8,7 +8,7 @@ helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v4.2.1 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true \

--- a/luan/cert-manager/cert-manager.sh
+++ b/luan/cert-manager/cert-manager.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CHART_VERSION="1.9.1"
+CHART_VERSION="1.12.2"
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update

--- a/luan/ingress/ingress-nginx.sh
+++ b/luan/ingress/ingress-nginx.sh
@@ -8,7 +8,7 @@ helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v4.2.1 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true \

--- a/lukay/cert-manager/cert-manager.sh
+++ b/lukay/cert-manager/cert-manager.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CHART_VERSION="1.9.1"
+CHART_VERSION="1.12.2"
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update

--- a/lukay/ingress/ingress-nginx.sh
+++ b/lukay/ingress/ingress-nginx.sh
@@ -9,7 +9,7 @@ helm upgrade --install \
   --atomic \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v4.2.1 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true

--- a/manke/cert-manager/cert-manager.sh
+++ b/manke/cert-manager/cert-manager.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CHART_VERSION="1.9.1"
+CHART_VERSION="1.12.2"
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update

--- a/manke/ingress/ingress-nginx.sh
+++ b/manke/ingress/ingress-nginx.sh
@@ -8,7 +8,7 @@ helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v4.2.1 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true \

--- a/namkueyen/cert-manager/cert-manager.sh
+++ b/namkueyen/cert-manager/cert-manager.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CHART_VERSION="1.9.1"
+CHART_VERSION="1.12.2"
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update

--- a/namkueyen/ingress/ingress-nginx.sh
+++ b/namkueyen/ingress/ingress-nginx.sh
@@ -8,7 +8,7 @@ helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v4.2.1 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true \

--- a/pillan/cert-manager/cert-manager.sh
+++ b/pillan/cert-manager/cert-manager.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CHART_VERSION="1.9.1"
+CHART_VERSION="1.12.2"
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update

--- a/pillan/ingress/ingress-nginx.sh
+++ b/pillan/ingress/ingress-nginx.sh
@@ -8,7 +8,7 @@ helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v4.2.1 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set controller.service.annotations."metallb\.universe\.tf\/loadBalancerIPs"=140.252.146.50 \
   --set defaultBackend.replicaCount=3 \

--- a/rancher.cp/cert-manager/cert-manager.sh
+++ b/rancher.cp/cert-manager/cert-manager.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CHART_VERSION="1.9.1"
+CHART_VERSION="1.12.2"
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update

--- a/rancher.cp/ingress/ingress-nginx.sh
+++ b/rancher.cp/ingress/ingress-nginx.sh
@@ -9,7 +9,7 @@ helm upgrade --install \
   --atomic \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v4.2.1 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true

--- a/rancher.dev/cert-manager/cert-manager.sh
+++ b/rancher.dev/cert-manager/cert-manager.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CHART_VERSION="1.9.1"
+CHART_VERSION="1.12.2"
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update

--- a/rancher.dev/ingress/ingress-nginx.sh
+++ b/rancher.dev/ingress/ingress-nginx.sh
@@ -8,7 +8,7 @@ helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v4.2.1 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true \

--- a/rancher.ls/cert-manager/cert-manager.sh
+++ b/rancher.ls/cert-manager/cert-manager.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CHART_VERSION="1.9.1"
+CHART_VERSION="1.12.2"
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update

--- a/rancher.ls/ingress/ingress-nginx.sh
+++ b/rancher.ls/ingress/ingress-nginx.sh
@@ -8,7 +8,7 @@ helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v4.2.1 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true \

--- a/rancher.tu/cert-manager/cert-manager.sh
+++ b/rancher.tu/cert-manager/cert-manager.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CHART_VERSION="1.9.1"
+CHART_VERSION="1.12.2"
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update

--- a/rancher.tu/ingress/ingress-nginx.sh
+++ b/rancher.tu/ingress/ingress-nginx.sh
@@ -8,7 +8,7 @@ helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v4.2.1 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true \

--- a/ruka/cert-manager/cert-manager.sh
+++ b/ruka/cert-manager/cert-manager.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CHART_VERSION="1.9.1"
+CHART_VERSION="1.12.2"
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update

--- a/ruka/ingress/ingress-nginx.sh
+++ b/ruka/ingress/ingress-nginx.sh
@@ -8,7 +8,7 @@ helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v4.2.1 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true \

--- a/ruka/ingress/lhn/ingress-nginx-lhn.sh
+++ b/ruka/ingress/lhn/ingress-nginx-lhn.sh
@@ -11,7 +11,7 @@ helm upgrade --install \
   --set controller.ingressClass="nginx-lhn" \
   --set controller.ingressClassResource.name="nginx-lhn" \
   --set controller.service.annotations."metallb\.universe\.tf\/address-pool"=lhn \
-  --version v4.2.1 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true \

--- a/yagan/ingress/ingress-nginx.sh
+++ b/yagan/ingress/ingress-nginx.sh
@@ -8,7 +8,7 @@ helm repo update
 helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v3.23.0 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true \

--- a/yepun/cert-manager/cert-manager.sh
+++ b/yepun/cert-manager/cert-manager.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CHART_VERSION="1.9.1"
+CHART_VERSION="1.12.2"
 
 helm repo add jetstack https://charts.jetstack.io
 helm repo update

--- a/yepun/ingress/ingress-nginx.sh
+++ b/yepun/ingress/ingress-nginx.sh
@@ -9,7 +9,7 @@ helm upgrade --install \
   --atomic \
   ingress-nginx ingress-nginx/ingress-nginx \
   --create-namespace --namespace ingress-nginx \
-  --version v4.2.1 \
+  --version v4.5.2 \
   --set controller.kind=DaemonSet \
   --set defaultBackend.replicaCount=3 \
   --set rbac.create=true


### PR DESCRIPTION
its needed to move forward with the current versions of both deployments in preparation to do k8s upgrade. (and because we are going out of support/EOL)