### PR TITLE
(konkong) fix lfa ingress for o11y s3

### DIFF
--- a/konkong/rook-ceph/s3/rgw-lfa.yaml
+++ b/konkong/rook-ceph/s3/rgw-lfa.yaml
@@ -38,7 +38,7 @@ metadata:
   name: rook-ceph-rgw-ingress
   namespace: rook-ceph
   annotations:
-    cert-manager.io/issuer: letsencrypt
+    cert-manager.io/cluster-issuer: letsencrypt
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:

--- a/konkong/rook-ceph/s3/rgw-o11y.yaml
+++ b/konkong/rook-ceph/s3/rgw-o11y.yaml
@@ -35,17 +35,17 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: rook-ceph-rgw-ingress
+  name: rook-ceph-rgw-ingress-o11y
   namespace: rook-ceph
   annotations:
-    cert-manager.io/issuer: letsencrypt
+    cert-manager.io/cluster-issuer: letsencrypt
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
   tls:
   - hosts:
     - s3.o11y.ls.lsst.org
-    secretName: rook-ceph-rgw-ingress-tls
+    secretName: rook-ceph-rgw-ingress-tls-o11y
   rules:
   - host: s3.o11y.ls.lsst.org
     http:
@@ -54,6 +54,6 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: rook-ceph-rgw-lfa
+            name: rook-ceph-rgw-o11y
             port:
               number: 80


### PR DESCRIPTION
the ingress for the o11y access had the same name as the original lfa s3 ingress so it got overwritten... also changed the certs issuer to cluster-issuer both certs got signed correctly.