### PR TITLE
(ayekan) Setup basic exporters to scrape machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ creds.sh
 secret.yaml
 values.yaml
 template.yaml
+
+ayekan/exporters/snmp-configmap.yaml

--- a/ayekan/exporters/blackbox-exporter.yaml
+++ b/ayekan/exporters/blackbox-exporter.yaml
@@ -1,0 +1,50 @@
+image:
+  tag: "v0.24.0"
+
+replicas: 1
+
+resources:
+  limits:
+    memory: 500Mi
+  requests:
+    memory: 500Mi
+
+serviceMonitor:
+  enabled: true
+  selfMonitor:
+    enabled: true
+    labels:
+      monitor: enabled
+  defaults:
+    labels:
+      monitor: enabled
+  targets:
+    - name: googlehttpcheck
+      url: https://google.com
+      hostname: google.com
+      interval: 60s
+      module: http_2xx
+
+prometheusRule:
+  enabled: false
+
+extraConfigmapMounts: []
+extraSecretMounts: []
+
+ingress:
+  enabled: true
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-dev
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/backend-protocol: HTTP
+    nginx.ingress.kubernetes.io/server-snippet: |
+      proxy_ssl_verify off;
+  hosts:
+    - host: blackbox-exporter.o11y.dev.lsst.org
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: tls-snmp-exporter-ingress
+      hosts:
+        - blackbox-exporter.o11y.dev.lsst.org

--- a/ayekan/exporters/blackbox-exporter.yaml
+++ b/ayekan/exporters/blackbox-exporter.yaml
@@ -48,3 +48,17 @@ ingress:
     - secretName: tls-snmp-exporter-ingress
       hosts:
         - blackbox-exporter.o11y.dev.lsst.org
+
+config:
+  modules:
+    http_2xx:
+      prober: http
+      timeout: 5s
+      http:
+        valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+        follow_redirects: true
+        preferred_ip_protocol: "ip4"
+    icmp:
+      prober: icmp
+      icmp:
+        preferred_ip_protocol: "ip4"

--- a/ayekan/exporters/deploy-exporters.sh
+++ b/ayekan/exporters/deploy-exporters.sh
@@ -2,6 +2,8 @@
 
 set -euxo pipefail
 
+NAMESPACE="monitoring"
+
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 
@@ -13,19 +15,19 @@ if [ -z ${LSST_SNMP_COMMUNITY+x} ]; then
     echo "Please set the LSST_SNMP_COMMUNITY variable before deploying exporters"
 	exit -1
 else
-    envsubst -o ./snmp-configmap.yaml ./snmp-configmap.tmpl
+    envsubst -i ./snmp-configmap.tmpl -o ./snmp-configmap.yaml
 fi
 
-kubectl create ns monitoring --dry-run=client -oyaml | kubectl apply -f -
-kubectl --namespace monitoring apply -f snmp-configmap.yaml
+kubectl create ns ${NAMESPACE} --dry-run=client -oyaml | kubectl apply -f -
+kubectl --namespace ${NAMESPACE} apply -f snmp-configmap.yaml
 helm upgrade --install snmp-exporter prometheus-community/prometheus-snmp-exporter \
-     --create-namespace --namespace monitoring \
+     --create-namespace --namespace ${NAMESPACE} \
      --atomic --timeout 15m0s \
      --version "1.8.1" \
      -f ./snmp-exporter.yaml
 
 helm upgrade --install blackbox-exporter prometheus-community/prometheus-blackbox-exporter \
-     --create-namespace --namespace monitoring \
+     --create-namespace --namespace ${NAMESPACE} \
      --atomic --timeout 15m0s \
      --version "8.4.0" \
      -f ./blackbox-exporter.yaml

--- a/ayekan/exporters/deploy-exporters.sh
+++ b/ayekan/exporters/deploy-exporters.sh
@@ -10,9 +10,11 @@ kubectl --namespace monitoring apply -f snmp-configmap.yaml
 helm upgrade --install snmp-exporter prometheus-community/prometheus-snmp-exporter \
      --create-namespace --namespace monitoring \
      --atomic --timeout 15m0s \
+     --version "1.8.1" \
      -f ./snmp-exporter.yaml
 
 helm upgrade --install blackbox-exporter prometheus-community/prometheus-blackbox-exporter \
      --create-namespace --namespace monitoring \
      --atomic --timeout 15m0s \
+     --version "8.4.0" \
      -f ./blackbox-exporter.yaml

--- a/ayekan/exporters/deploy-exporters.sh
+++ b/ayekan/exporters/deploy-exporters.sh
@@ -1,9 +1,20 @@
 #! /usr/bin/env bash
 
-set -ex
+set -euxo pipefail
 
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
+
+if [ -f ./snmp-configmap.yaml ]; then
+    rm ./snmp-configmap.yaml
+fi
+
+if [ -z ${LSST_SNMP_COMMUNITY+x} ]; then
+    echo "Please set the LSST_SNMP_COMMUNITY variable before deploying exporters"
+	exit -1
+else
+    envsubst -o ./snmp-configmap.yaml ./snmp-configmap.tmpl
+fi
 
 kubectl create ns monitoring --dry-run=client -oyaml | kubectl apply -f -
 kubectl --namespace monitoring apply -f snmp-configmap.yaml

--- a/ayekan/exporters/deploy-exporters.sh
+++ b/ayekan/exporters/deploy-exporters.sh
@@ -1,0 +1,18 @@
+#! /usr/bin/env bash
+
+set -ex
+
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+
+kubectl create ns monitoring --dry-run=client -oyaml | kubectl apply -f -
+kubectl --namespace monitoring apply -f snmp-configmap.yaml
+helm upgrade --install snmp-exporter prometheus-community/prometheus-snmp-exporter \
+     --create-namespace --namespace monitoring \
+     --atomic --timeout 15m0s \
+     -f ./snmp-exporter.yaml
+
+helm upgrade --install blackbox-exporter prometheus-community/prometheus-blackbox-exporter \
+     --create-namespace --namespace monitoring \
+     --atomic --timeout 15m0s \
+     -f ./blackbox-exporter.yaml

--- a/ayekan/exporters/deploy-exporters.sh
+++ b/ayekan/exporters/deploy-exporters.sh
@@ -13,7 +13,7 @@ fi
 
 if [ -z ${LSST_SNMP_COMMUNITY+x} ]; then
     echo "Please set the LSST_SNMP_COMMUNITY variable before deploying exporters"
-	exit -1
+	exit 1
 else
     envsubst -i ./snmp-configmap.tmpl -o ./snmp-configmap.yaml
 fi

--- a/ayekan/exporters/snmp-configmap.tmpl
+++ b/ayekan/exporters/snmp-configmap.tmpl
@@ -7,13 +7,13 @@ data:
   snmp.yml: |
     auths:
       public_v1:
-        community: public
+        community: ${LSST_SNMP_COMMUNITY}
         security_level: noAuthNoPriv
         auth_protocol: MD5
         priv_protocol: DES
         version: 1
       public_v2:
-        community: public
+        community: ${LSST_SNMP_COMMUNITY}
         security_level: noAuthNoPriv
         auth_protocol: MD5
         priv_protocol: DES

--- a/ayekan/exporters/snmp-configmap.yaml
+++ b/ayekan/exporters/snmp-configmap.yaml
@@ -1,0 +1,1278 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: snmp-config
+data:
+  snmp.yml: |
+    auths:
+      public_v1:
+        community: public
+        security_level: noAuthNoPriv
+        auth_protocol: MD5
+        priv_protocol: DES
+        version: 1
+      public_v2:
+        community: public
+        security_level: noAuthNoPriv
+        auth_protocol: MD5
+        priv_protocol: DES
+        version: 2
+    modules:
+      if_mib:
+        walk:
+        - 1.3.6.1.2.1.2
+        - 1.3.6.1.2.1.31.1.1
+        get:
+        - 1.3.6.1.2.1.1.3.0
+        metrics:
+        - name: sysUpTime
+          oid: 1.3.6.1.2.1.1.3
+          type: gauge
+          help: The time (in hundredths of a second) since the network management portion
+            of the system was last re-initialized. - 1.3.6.1.2.1.1.3
+        - name: ifNumber
+          oid: 1.3.6.1.2.1.2.1
+          type: gauge
+          help: The number of network interfaces (regardless of their current state) present
+            on this system. - 1.3.6.1.2.1.2.1
+        - name: ifIndex
+          oid: 1.3.6.1.2.1.2.2.1.1
+          type: gauge
+          help: A unique value, greater than zero, for each interface - 1.3.6.1.2.1.2.2.1.1
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifType
+          oid: 1.3.6.1.2.1.2.2.1.3
+          type: EnumAsInfo
+          help: The type of interface - 1.3.6.1.2.1.2.2.1.3
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+          enum_values:
+            1: other
+            2: regular1822
+            3: hdh1822
+            4: ddnX25
+            5: rfc877x25
+            6: ethernetCsmacd
+            7: iso88023Csmacd
+            8: iso88024TokenBus
+            9: iso88025TokenRing
+            10: iso88026Man
+            11: starLan
+            12: proteon10Mbit
+            13: proteon80Mbit
+            14: hyperchannel
+            15: fddi
+            16: lapb
+            17: sdlc
+            18: ds1
+            19: e1
+            20: basicISDN
+            21: primaryISDN
+            22: propPointToPointSerial
+            23: ppp
+            24: softwareLoopback
+            25: eon
+            26: ethernet3Mbit
+            27: nsip
+            28: slip
+            29: ultra
+            30: ds3
+            31: sip
+            32: frameRelay
+            33: rs232
+            34: para
+            35: arcnet
+            36: arcnetPlus
+            37: atm
+            38: miox25
+            39: sonet
+            40: x25ple
+            41: iso88022llc
+            42: localTalk
+            43: smdsDxi
+            44: frameRelayService
+            45: v35
+            46: hssi
+            47: hippi
+            48: modem
+            49: aal5
+            50: sonetPath
+            51: sonetVT
+            52: smdsIcip
+            53: propVirtual
+            54: propMultiplexor
+            55: ieee80212
+            56: fibreChannel
+            57: hippiInterface
+            58: frameRelayInterconnect
+            59: aflane8023
+            60: aflane8025
+            61: cctEmul
+            62: fastEther
+            63: isdn
+            64: v11
+            65: v36
+            66: g703at64k
+            67: g703at2mb
+            68: qllc
+            69: fastEtherFX
+            70: channel
+            71: ieee80211
+            72: ibm370parChan
+            73: escon
+            74: dlsw
+            75: isdns
+            76: isdnu
+            77: lapd
+            78: ipSwitch
+            79: rsrb
+            80: atmLogical
+            81: ds0
+            82: ds0Bundle
+            83: bsc
+            84: async
+            85: cnr
+            86: iso88025Dtr
+            87: eplrs
+            88: arap
+            89: propCnls
+            90: hostPad
+            91: termPad
+            92: frameRelayMPI
+            93: x213
+            94: adsl
+            95: radsl
+            96: sdsl
+            97: vdsl
+            98: iso88025CRFPInt
+            99: myrinet
+            100: voiceEM
+            101: voiceFXO
+            102: voiceFXS
+            103: voiceEncap
+            104: voiceOverIp
+            105: atmDxi
+            106: atmFuni
+            107: atmIma
+            108: pppMultilinkBundle
+            109: ipOverCdlc
+            110: ipOverClaw
+            111: stackToStack
+            112: virtualIpAddress
+            113: mpc
+            114: ipOverAtm
+            115: iso88025Fiber
+            116: tdlc
+            117: gigabitEthernet
+            118: hdlc
+            119: lapf
+            120: v37
+            121: x25mlp
+            122: x25huntGroup
+            123: transpHdlc
+            124: interleave
+            125: fast
+            126: ip
+            127: docsCableMaclayer
+            128: docsCableDownstream
+            129: docsCableUpstream
+            130: a12MppSwitch
+            131: tunnel
+            132: coffee
+            133: ces
+            134: atmSubInterface
+            135: l2vlan
+            136: l3ipvlan
+            137: l3ipxvlan
+            138: digitalPowerline
+            139: mediaMailOverIp
+            140: dtm
+            141: dcn
+            142: ipForward
+            143: msdsl
+            144: ieee1394
+            145: if-gsn
+            146: dvbRccMacLayer
+            147: dvbRccDownstream
+            148: dvbRccUpstream
+            149: atmVirtual
+            150: mplsTunnel
+            151: srp
+            152: voiceOverAtm
+            153: voiceOverFrameRelay
+            154: idsl
+            155: compositeLink
+            156: ss7SigLink
+            157: propWirelessP2P
+            158: frForward
+            159: rfc1483
+            160: usb
+            161: ieee8023adLag
+            162: bgppolicyaccounting
+            163: frf16MfrBundle
+            164: h323Gatekeeper
+            165: h323Proxy
+            166: mpls
+            167: mfSigLink
+            168: hdsl2
+            169: shdsl
+            170: ds1FDL
+            171: pos
+            172: dvbAsiIn
+            173: dvbAsiOut
+            174: plc
+            175: nfas
+            176: tr008
+            177: gr303RDT
+            178: gr303IDT
+            179: isup
+            180: propDocsWirelessMaclayer
+            181: propDocsWirelessDownstream
+            182: propDocsWirelessUpstream
+            183: hiperlan2
+            184: propBWAp2Mp
+            185: sonetOverheadChannel
+            186: digitalWrapperOverheadChannel
+            187: aal2
+            188: radioMAC
+            189: atmRadio
+            190: imt
+            191: mvl
+            192: reachDSL
+            193: frDlciEndPt
+            194: atmVciEndPt
+            195: opticalChannel
+            196: opticalTransport
+            197: propAtm
+            198: voiceOverCable
+            199: infiniband
+            200: teLink
+            201: q2931
+            202: virtualTg
+            203: sipTg
+            204: sipSig
+            205: docsCableUpstreamChannel
+            206: econet
+            207: pon155
+            208: pon622
+            209: bridge
+            210: linegroup
+            211: voiceEMFGD
+            212: voiceFGDEANA
+            213: voiceDID
+            214: mpegTransport
+            215: sixToFour
+            216: gtp
+            217: pdnEtherLoop1
+            218: pdnEtherLoop2
+            219: opticalChannelGroup
+            220: homepna
+            221: gfp
+            222: ciscoISLvlan
+            223: actelisMetaLOOP
+            224: fcipLink
+            225: rpr
+            226: qam
+            227: lmp
+            228: cblVectaStar
+            229: docsCableMCmtsDownstream
+            230: adsl2
+            231: macSecControlledIF
+            232: macSecUncontrolledIF
+            233: aviciOpticalEther
+            234: atmbond
+            235: voiceFGDOS
+            236: mocaVersion1
+            237: ieee80216WMAN
+            238: adsl2plus
+            239: dvbRcsMacLayer
+            240: dvbTdm
+            241: dvbRcsTdma
+            242: x86Laps
+            243: wwanPP
+            244: wwanPP2
+            245: voiceEBS
+            246: ifPwType
+            247: ilan
+            248: pip
+            249: aluELP
+            250: gpon
+            251: vdsl2
+            252: capwapDot11Profile
+            253: capwapDot11Bss
+            254: capwapWtpVirtualRadio
+            255: bits
+            256: docsCableUpstreamRfPort
+            257: cableDownstreamRfPort
+            258: vmwareVirtualNic
+            259: ieee802154
+            260: otnOdu
+            261: otnOtu
+            262: ifVfiType
+            263: g9981
+            264: g9982
+            265: g9983
+            266: aluEpon
+            267: aluEponOnu
+            268: aluEponPhysicalUni
+            269: aluEponLogicalLink
+            270: aluGponOnu
+            271: aluGponPhysicalUni
+            272: vmwareNicTeam
+            277: docsOfdmDownstream
+            278: docsOfdmaUpstream
+            279: gfast
+            280: sdci
+            281: xboxWireless
+            282: fastdsl
+            283: docsCableScte55d1FwdOob
+            284: docsCableScte55d1RetOob
+            285: docsCableScte55d2DsOob
+            286: docsCableScte55d2UsOob
+            287: docsCableNdf
+            288: docsCableNdr
+            289: ptm
+            290: ghn
+            291: otnOtsi
+            292: otnOtuc
+            293: otnOduc
+            294: otnOtsig
+            295: microwaveCarrierTermination
+            296: microwaveRadioLinkTerminal
+            297: ieee8021axDrni
+            298: ax25
+            299: ieee19061nanocom
+            300: cpri
+            301: omni
+            302: roe
+            303: p2pOverLan
+        - name: ifMtu
+          oid: 1.3.6.1.2.1.2.2.1.4
+          type: gauge
+          help: The size of the largest packet which can be sent/received on the interface,
+            specified in octets - 1.3.6.1.2.1.2.2.1.4
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifSpeed
+          oid: 1.3.6.1.2.1.2.2.1.5
+          type: gauge
+          help: An estimate of the interface's current bandwidth in bits per second -
+            1.3.6.1.2.1.2.2.1.5
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifPhysAddress
+          oid: 1.3.6.1.2.1.2.2.1.6
+          type: PhysAddress48
+          help: The interface's address at its protocol sub-layer - 1.3.6.1.2.1.2.2.1.6
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifAdminStatus
+          oid: 1.3.6.1.2.1.2.2.1.7
+          type: gauge
+          help: The desired state of the interface - 1.3.6.1.2.1.2.2.1.7
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+          enum_values:
+            1: up
+            2: down
+            3: testing
+        - name: ifOperStatus
+          oid: 1.3.6.1.2.1.2.2.1.8
+          type: gauge
+          help: The current operational state of the interface - 1.3.6.1.2.1.2.2.1.8
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+          enum_values:
+            1: up
+            2: down
+            3: testing
+            4: unknown
+            5: dormant
+            6: notPresent
+            7: lowerLayerDown
+        - name: ifLastChange
+          oid: 1.3.6.1.2.1.2.2.1.9
+          type: gauge
+          help: The value of sysUpTime at the time the interface entered its current operational
+            state - 1.3.6.1.2.1.2.2.1.9
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifInOctets
+          oid: 1.3.6.1.2.1.2.2.1.10
+          type: counter
+          help: The total number of octets received on the interface, including framing
+            characters - 1.3.6.1.2.1.2.2.1.10
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifInUcastPkts
+          oid: 1.3.6.1.2.1.2.2.1.11
+          type: counter
+          help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+            which were not addressed to a multicast or broadcast address at this sub-layer
+            - 1.3.6.1.2.1.2.2.1.11
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifInNUcastPkts
+          oid: 1.3.6.1.2.1.2.2.1.12
+          type: counter
+          help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+            which were addressed to a multicast or broadcast address at this sub-layer
+            - 1.3.6.1.2.1.2.2.1.12
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifInDiscards
+          oid: 1.3.6.1.2.1.2.2.1.13
+          type: counter
+          help: The number of inbound packets which were chosen to be discarded even though
+            no errors had been detected to prevent their being deliverable to a higher-layer
+            protocol - 1.3.6.1.2.1.2.2.1.13
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifInErrors
+          oid: 1.3.6.1.2.1.2.2.1.14
+          type: counter
+          help: For packet-oriented interfaces, the number of inbound packets that contained
+            errors preventing them from being deliverable to a higher-layer protocol -
+            1.3.6.1.2.1.2.2.1.14
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifInUnknownProtos
+          oid: 1.3.6.1.2.1.2.2.1.15
+          type: counter
+          help: For packet-oriented interfaces, the number of packets received via the
+            interface which were discarded because of an unknown or unsupported protocol
+            - 1.3.6.1.2.1.2.2.1.15
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifOutOctets
+          oid: 1.3.6.1.2.1.2.2.1.16
+          type: counter
+          help: The total number of octets transmitted out of the interface, including
+            framing characters - 1.3.6.1.2.1.2.2.1.16
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifOutUcastPkts
+          oid: 1.3.6.1.2.1.2.2.1.17
+          type: counter
+          help: The total number of packets that higher-level protocols requested be transmitted,
+            and which were not addressed to a multicast or broadcast address at this sub-layer,
+            including those that were discarded or not sent - 1.3.6.1.2.1.2.2.1.17
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifOutNUcastPkts
+          oid: 1.3.6.1.2.1.2.2.1.18
+          type: counter
+          help: The total number of packets that higher-level protocols requested be transmitted,
+            and which were addressed to a multicast or broadcast address at this sub-layer,
+            including those that were discarded or not sent - 1.3.6.1.2.1.2.2.1.18
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifOutDiscards
+          oid: 1.3.6.1.2.1.2.2.1.19
+          type: counter
+          help: The number of outbound packets which were chosen to be discarded even
+            though no errors had been detected to prevent their being transmitted - 1.3.6.1.2.1.2.2.1.19
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifOutErrors
+          oid: 1.3.6.1.2.1.2.2.1.20
+          type: counter
+          help: For packet-oriented interfaces, the number of outbound packets that could
+            not be transmitted because of errors - 1.3.6.1.2.1.2.2.1.20
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifOutQLen
+          oid: 1.3.6.1.2.1.2.2.1.21
+          type: gauge
+          help: The length of the output packet queue (in packets). - 1.3.6.1.2.1.2.2.1.21
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifSpecific
+          oid: 1.3.6.1.2.1.2.2.1.22
+          type: OctetString
+          help: A reference to MIB definitions specific to the particular media being
+            used to realize the interface - 1.3.6.1.2.1.2.2.1.22
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifInMulticastPkts
+          oid: 1.3.6.1.2.1.31.1.1.1.2
+          type: counter
+          help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+            which were addressed to a multicast address at this sub-layer - 1.3.6.1.2.1.31.1.1.1.2
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifInBroadcastPkts
+          oid: 1.3.6.1.2.1.31.1.1.1.3
+          type: counter
+          help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+            which were addressed to a broadcast address at this sub-layer - 1.3.6.1.2.1.31.1.1.1.3
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifOutMulticastPkts
+          oid: 1.3.6.1.2.1.31.1.1.1.4
+          type: counter
+          help: The total number of packets that higher-level protocols requested be transmitted,
+            and which were addressed to a multicast address at this sub-layer, including
+            those that were discarded or not sent - 1.3.6.1.2.1.31.1.1.1.4
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifOutBroadcastPkts
+          oid: 1.3.6.1.2.1.31.1.1.1.5
+          type: counter
+          help: The total number of packets that higher-level protocols requested be transmitted,
+            and which were addressed to a broadcast address at this sub-layer, including
+            those that were discarded or not sent - 1.3.6.1.2.1.31.1.1.1.5
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifHCInOctets
+          oid: 1.3.6.1.2.1.31.1.1.1.6
+          type: counter
+          help: The total number of octets received on the interface, including framing
+            characters - 1.3.6.1.2.1.31.1.1.1.6
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifHCInUcastPkts
+          oid: 1.3.6.1.2.1.31.1.1.1.7
+          type: counter
+          help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+            which were not addressed to a multicast or broadcast address at this sub-layer
+            - 1.3.6.1.2.1.31.1.1.1.7
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifHCInMulticastPkts
+          oid: 1.3.6.1.2.1.31.1.1.1.8
+          type: counter
+          help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+            which were addressed to a multicast address at this sub-layer - 1.3.6.1.2.1.31.1.1.1.8
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifHCInBroadcastPkts
+          oid: 1.3.6.1.2.1.31.1.1.1.9
+          type: counter
+          help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+            which were addressed to a broadcast address at this sub-layer - 1.3.6.1.2.1.31.1.1.1.9
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifHCOutOctets
+          oid: 1.3.6.1.2.1.31.1.1.1.10
+          type: counter
+          help: The total number of octets transmitted out of the interface, including
+            framing characters - 1.3.6.1.2.1.31.1.1.1.10
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifHCOutUcastPkts
+          oid: 1.3.6.1.2.1.31.1.1.1.11
+          type: counter
+          help: The total number of packets that higher-level protocols requested be transmitted,
+            and which were not addressed to a multicast or broadcast address at this sub-layer,
+            including those that were discarded or not sent - 1.3.6.1.2.1.31.1.1.1.11
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifHCOutMulticastPkts
+          oid: 1.3.6.1.2.1.31.1.1.1.12
+          type: counter
+          help: The total number of packets that higher-level protocols requested be transmitted,
+            and which were addressed to a multicast address at this sub-layer, including
+            those that were discarded or not sent - 1.3.6.1.2.1.31.1.1.1.12
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifHCOutBroadcastPkts
+          oid: 1.3.6.1.2.1.31.1.1.1.13
+          type: counter
+          help: The total number of packets that higher-level protocols requested be transmitted,
+            and which were addressed to a broadcast address at this sub-layer, including
+            those that were discarded or not sent - 1.3.6.1.2.1.31.1.1.1.13
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifLinkUpDownTrapEnable
+          oid: 1.3.6.1.2.1.31.1.1.1.14
+          type: gauge
+          help: Indicates whether linkUp/linkDown traps should be generated for this interface
+            - 1.3.6.1.2.1.31.1.1.1.14
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+          enum_values:
+            1: enabled
+            2: disabled
+        - name: ifHighSpeed
+          oid: 1.3.6.1.2.1.31.1.1.1.15
+          type: gauge
+          help: An estimate of the interface's current bandwidth in units of 1,000,000
+            bits per second - 1.3.6.1.2.1.31.1.1.1.15
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+        - name: ifPromiscuousMode
+          oid: 1.3.6.1.2.1.31.1.1.1.16
+          type: gauge
+          help: This object has a value of false(2) if this interface only accepts packets/frames
+            that are addressed to this station - 1.3.6.1.2.1.31.1.1.1.16
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+          enum_values:
+            1: "true"
+            2: "false"
+        - name: ifConnectorPresent
+          oid: 1.3.6.1.2.1.31.1.1.1.17
+          type: gauge
+          help: This object has the value 'true(1)' if the interface sublayer has a physical
+            connector and the value 'false(2)' otherwise. - 1.3.6.1.2.1.31.1.1.1.17
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString
+          enum_values:
+            1: "true"
+            2: "false"
+        - name: ifCounterDiscontinuityTime
+          oid: 1.3.6.1.2.1.31.1.1.1.19
+          type: gauge
+          help: The value of sysUpTime on the most recent occasion at which any one or
+            more of this interface's counters suffered a discontinuity - 1.3.6.1.2.1.31.1.1.1.19
+          indexes:
+          - labelname: ifIndex
+            type: gauge
+          lookups:
+          - labels:
+            - ifIndex
+            labelname: ifAlias
+            oid: 1.3.6.1.2.1.31.1.1.1.18
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifDescr
+            oid: 1.3.6.1.2.1.2.2.1.2
+            type: DisplayString
+          - labels:
+            - ifIndex
+            labelname: ifName
+            oid: 1.3.6.1.2.1.31.1.1.1.1
+            type: DisplayString

--- a/ayekan/exporters/snmp-exporter.yaml
+++ b/ayekan/exporters/snmp-exporter.yaml
@@ -1,0 +1,37 @@
+image:
+  tag: "v0.23.0"
+
+replicas: 1
+
+resources:
+  limits:
+    memory: 500Mi
+  requests:
+    memory: 500Mi
+
+serviceMonitor:
+  enabled: true
+
+extraConfigmapMounts:
+  - name: snmp-exporter-config
+    mountPath: /etc/snmp_exporter/snmp.yml
+    configMap: snmp-config
+    subPath: snmp.yml
+    readOnly: true
+    defaultmode: 420
+extraSecretMounts: []
+
+ingress:
+  enabled: true
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-dev
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/backend-protocol: HTTP
+    nginx.ingress.kubernetes.io/server-snippet: |
+      proxy_ssl_verify off;
+  hosts:
+    - snmp-exporter.o11y.dev.lsst.org
+  tls:
+    - secretName: tls-snmp-exporter-ingress
+      hosts:
+        - snmp-exporter.o11y.dev.lsst.org

--- a/ayekan/prometheus/values.yaml
+++ b/ayekan/prometheus/values.yaml
@@ -5,7 +5,38 @@ prometheus:
       matchLabels:
         o11y.eu/monitor: "enabled"
     remoteWrite:
-      - url: http://ayekan-mimir-gateway.mimir.svc:80/api/v1/push
+      - url: http://ayekan-mimir-gateway.mimir:80/api/v1/push
+    additionalScrapeConfigs:
+      - job_name: blackbox-ping-dev
+        metrics_path: /probe
+        params:
+          module: [icmp]
+        puppetdb_sd_configs:
+          - url: "http://puppetdb.dev.lsst.org:8080"
+            query: "resources { type = \"Class\" and title = \"Prometheus::Node_exporter\" }"
+            refresh_interval: "30s"
+            follow_redirects: true
+            include_parameters: true
+            enable_http2: true
+        relabel_configs: &k8s-blackbox-monitoring
+          - source_labels: [__meta_puppetdb_certname]
+            target_label: __param_target
+          - source_labels: [__param_target]
+            target_label: instance
+          - target_label: __address__
+            replacement: "blackbox-exporter-prometheus-blackbox-exporter.monitoring:9115"
+      - job_name: blackbox-ping-ls
+        metrics_path: /probe
+        params:
+          module: [icmp]
+        puppetdb_sd_configs:
+          - url: "http://puppetdb.ls.lsst.org:8080"
+            query: "resources { type = \"Class\" and title = \"Prometheus::Node_exporter\" }"
+            refresh_interval: "30s"
+            follow_redirects: true
+            include_parameters: true
+            enable_http2: true
+        relabel_configs: *k8s-blackbox-monitoring
   ingress:
     enabled: true
     annotations:


### PR DESCRIPTION
This should cause the blackbox exporter to start probing all the node-exporter machines.

TODO: configure some SNMP targets as well