### PR TITLE
(ayekan) enable slack/squadcast connection for alertmanager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ values.yaml
 template.yaml
 
 ayekan/exporters/snmp-configmap.yaml
+
+*secret.yaml

--- a/ayekan/prometheus/prometheus.sh
+++ b/ayekan/prometheus/prometheus.sh
@@ -9,7 +9,6 @@ helm repo update
 helm upgrade --install \
   kube-prometheus-stack prometheus-community/kube-prometheus-stack \
   --create-namespace --namespace kube-prometheus-stack \
-  --set "alertmanager.config.receivers[1].slack_configs[0].api_url=${O11Y_SLACK_API_URL}" \
   -f ./values.yaml \
   --atomic
 

--- a/ayekan/prometheus/prometheus.sh
+++ b/ayekan/prometheus/prometheus.sh
@@ -9,6 +9,7 @@ helm repo update
 helm upgrade --install \
   kube-prometheus-stack prometheus-community/kube-prometheus-stack \
   --create-namespace --namespace kube-prometheus-stack \
+  --set alertmanager.config.receivers.[1].slack_configs.[1].api_url ${O11Y_SLACK_API_URL}
   -f ./values.yaml \
   --atomic
 

--- a/ayekan/prometheus/prometheus.sh
+++ b/ayekan/prometheus/prometheus.sh
@@ -9,7 +9,7 @@ helm repo update
 helm upgrade --install \
   kube-prometheus-stack prometheus-community/kube-prometheus-stack \
   --create-namespace --namespace kube-prometheus-stack \
-  --set alertmanager.config.receivers.[1].slack_configs.[1].api_url ${O11Y_SLACK_API_URL}
+  --set "alertmanager.config.receivers[1].slack_configs[0].api_url=${O11Y_SLACK_API_URL}" \
   -f ./values.yaml \
   --atomic
 

--- a/ayekan/prometheus/values.yaml
+++ b/ayekan/prometheus/values.yaml
@@ -95,6 +95,8 @@ prometheus:
 alertmanager:
   alertmanagerSpec:
     externalUrl: https://alertmanager.ayekan.ls.lsst.org
+    secrets:
+      - o11y-slack
   ingress:
     enabled: true
     annotations:
@@ -115,6 +117,7 @@ alertmanager:
   config:
     global:
       resolve_timeout: 5m
+      slack_api_url_file: /etc/alertmanager/secrets/o11y-slack
     route:
       group_by: ["namespace", "cluster"]
       group_wait: 30s

--- a/ayekan/prometheus/values.yaml
+++ b/ayekan/prometheus/values.yaml
@@ -96,7 +96,7 @@ alertmanager:
   alertmanagerSpec:
     externalUrl: https://alertmanager.ayekan.ls.lsst.org
     secrets:
-      - o11y-slack
+      - o11y-webhooks
   ingress:
     enabled: true
     annotations:
@@ -117,7 +117,7 @@ alertmanager:
   config:
     global:
       resolve_timeout: 5m
-      slack_api_url_file: /etc/alertmanager/secrets/o11y-slack
+      slack_api_url_file: /etc/alertmanager/secrets/o11y-webhooks/o11y-slack
     route:
       group_by: ["namespace", "cluster"]
       group_wait: 30s
@@ -127,14 +127,41 @@ alertmanager:
       routes:
         - receiver: "null"
           matchers:
-            - alertname =~ "InfoInhibitor|Watchdog"
+            - alertname = "InfoInhibitor"
+        - receiver: "watchdog"
+          matchers:
+            - alertname = "Watchdog"
+        - receiver: "squadcast-test"
+          matchers:
+            - receiver =~ ".*,squadcast,.*"
+          continue: true
     receivers:
       - name: "null"
+      - name: "watchdog"
       - name: "slack-test"
         slack_configs:
           - username: "ayekan-prometheus"
             channel: "#rubinobs-monitoring-test"
             send_resolved: true
+      - name: "squadcast-test"
+        webhook_configs:
+          - url_file: /etc/alertmanger/secrets/o11y-webhooks/o11y-squadcast
+    inhibit_rules:
+      - source_matchers:
+          - alertname = "InfoInhibitor"
+        target_matchers:
+          - severity = "info"
+        equal: ["namespace"]
+      - source_matchers:
+          - severity = "critical"
+        target_matchers:
+          - severity =~ "info|warning"
+        equal: ["alertname"]
+      - source_matchers:
+          - severity = "warning"
+        target_matchers:
+          - severity = "info"
+        equal: ["alertname"]
     templates:
       - "/etc/alertmanager/config/*.tmpl"
 

--- a/ayekan/prometheus/values.yaml
+++ b/ayekan/prometheus/values.yaml
@@ -1,6 +1,7 @@
 ---
 prometheus:
   prometheusSpec:
+    externalUrl: https://prometheus.ayekan.ls.lsst.org
     serviceMonitorNamespaceSelector:
       matchLabels:
         o11y.eu/monitor: "enabled"
@@ -92,6 +93,25 @@ prometheus:
           - prometheus.ayekan.ls.lsst.org
 
 alertmanager:
+  alertmanagerSpec:
+    externalUrl: https://alertmanager.ayekan.ls.lsst.org
+  ingress:
+    enabled: true
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/backend-protocol: HTTP
+      nginx.ingress.kubernetes.io/server-snippet: |
+        proxy_ssl_verify off;
+    paths:
+      - /
+    pathType: Prefix
+    hosts:
+      - alertmanager.ayekan.ls.lsst.org
+    tls:
+      - secretName: tls-alertmanager-ingress
+        hosts:
+          - alertmanager.ayekan.ls.lsst.org
   config:
     global:
       resolve_timeout: 5m

--- a/ayekan/prometheus/values.yaml
+++ b/ayekan/prometheus/values.yaml
@@ -90,6 +90,31 @@ prometheus:
       - secretName: tls-prometheus-ingress
         hosts:
           - prometheus.ayekan.ls.lsst.org
+
+alertmanager:
+  config:
+    global:
+      resolve_timeout: 5m
+    route:
+      group_by: ["namespace", "cluster"]
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 24h
+      receiver: "slack-test"
+      routes:
+        - receiver: "null"
+          matchers:
+            - alertname =~ "InfoInhibitor|Watchdog"
+    receivers:
+      - name: "null"
+      - name: "slack-test"
+        slack_configs:
+          - username: "ayekan-prometheus"
+            channel: "#rubinobs-monitoring-test"
+            send_resolved: true
+    templates:
+      - "/etc/alertmanager/config/*.tmpl"
+
 grafana:
   persistence:
     enabled: true


### PR DESCRIPTION
This enabled the slack connection from alertmanager, enabling alert sending to slack. Meanwhile also correctly setting the externalURL of both prometheus and alertmanager (to make the alerts functional).

Only a DNS entry for `alertmanager.ayekan.ls.lsst.org` needs to be configured (as currently the links fail).

If somebody knows a better way around `--set "alertmanager.config.receivers[1].slack_configs[0].api_url=${O11Y_SLACK_API_URL}` I'd be happy to replace the fragile bash.