### PR TITLE
(ayekan) enable grafana persistence across boots

### DIFF
--- a/ayekan/prometheus/values.yaml
+++ b/ayekan/prometheus/values.yaml
@@ -55,6 +55,8 @@ prometheus:
         hosts:
           - prometheus.ayekan.ls.lsst.org
 grafana:
+  persistence:
+    enabled: true
   ingress:
     enabled: true
     annotations:


### PR DESCRIPTION
Assigns 10GB persistent storage to the Grafana instances in the helm chart.