### PR TITLE
(yepun) Kuma monitoring redeployment 

### DIFF
--- a/yepun/kuma/ingress-kuma.yaml
+++ b/yepun/kuma/ingress-kuma.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/backend-protocol: HTTP
+    nginx.ingress.kubernetes.io/server-snippet: |
+      proxy_ssl_verify off;
+  name: it-kuma-dashboard
+  namespace: kuma
+spec:
+  rules:
+  - host: it-kuma01.cp.lsst.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: my-uptime-kuma
+            port:
+              name:
+              number: 3001
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - it-kuma01.cp.lsst.org
+    secretName: it-kuma01-dashboard-ingress-tls

--- a/yepun/kuma/kuma.sh
+++ b/yepun/kuma/kuma.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ex
+
+helm repo add uptime-kuma https://dirsigler.github.io/uptime-kuma-helm
+helm repo update
+
+helm install my-uptime-kuma uptime-kuma/uptime-kuma \
+    --version 2.17.0 \
+    --create-namespace --namespace kuma \
+    --atomic
+
+kubectl apply -f ingress-kuma.yaml


### PR DESCRIPTION
Redeploying Kuma monitoring to normalize its installation using our k8s-cookbook.

Helm chart used: https://artifacthub.io/packages/helm/uptime-kuma/uptime-kuma 

