### PR TITLE
(ayekan) enable monitoring on Mimir

### DIFF
--- a/ayekan/mimir/values.yaml
+++ b/ayekan/mimir/values.yaml
@@ -1,4 +1,21 @@
 # Mimir components
+metaMonitoring:
+  dashboards:
+    enabled: true
+    labels:
+      o11y.eu/monitor: enabled
+      release: kube-prometheus-stack
+      grafana_dashboard: "1"
+  serviceMonitor:
+    enabled: true
+    labels:
+      o11y.eu/monitor: enabled
+      release: kube-prometheus-stack
+  prometheusRule:
+    enabled: true
+    labels:
+      o11y.eu/monitor: enabled
+      release: kube-prometheus-stack
 mimir:
   structuredConfig:
     common:


### PR DESCRIPTION
Enable the `metamonitoring` for Mimir, which implements alerting rules, dashboards and serviceMonitors for the Mimir components.