### PR TITLE
(*) add external-secrets operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 k8s cookbook
 ============
+
+| :exclamation: We are migrating to using Fleet for most deployments.  The `external-secrets` operator should be used to manage secrets in all deployments which aren't necessary for bootstraping secrets management.|
+|---|

--- a/ayekan/external-secrets/.gitignore
+++ b/ayekan/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/ayekan/external-secrets/README.md
+++ b/ayekan/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/ayekan/external-secrets/clustersecretstore-onepassword.yaml
+++ b/ayekan/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.dev.lsst.org
+      vaults:
+        Dev: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/ayekan/external-secrets/external-secrets.sh
+++ b/ayekan/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/ayekan/external-secrets/fetch-credentials.sh
+++ b/ayekan/external-secrets/fetch-credentials.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 ONEPASS_TOKEN="$(op item get "connect.dev.lsst.org Access Token: ayekan.dev.lsst.org" --fields credential)"
 
 cat > secret-onepassword-token.yaml << END

--- a/ayekan/external-secrets/fetch-credentials.sh
+++ b/ayekan/external-secrets/fetch-credentials.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+ONEPASS_TOKEN="$(op item get "connect.dev.lsst.org Access Token: ayekan.dev.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/ayekan/rke/.gitignore
+++ b/ayekan/rke/.gitignore
@@ -1,1 +1,3 @@
-../.././template/rke/.gitignore
+cluster.rkestate
+kube_config_cluster.yml
+*.tar.gz

--- a/chango/external-secrets/.gitignore
+++ b/chango/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/chango/external-secrets/README.md
+++ b/chango/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/chango/external-secrets/clustersecretstore-onepassword.yaml
+++ b/chango/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.ls.lsst.org
+      vaults:
+        ls: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/chango/external-secrets/external-secrets.sh
+++ b/chango/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/chango/external-secrets/fetch-credentials.sh
+++ b/chango/external-secrets/fetch-credentials.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
+ONEPASS_TOKEN="$(op item get "connect.ls.lsst.org Access Token: chango.ls.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/chonchon/external-secrets/.gitignore
+++ b/chonchon/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/chonchon/external-secrets/README.md
+++ b/chonchon/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/chonchon/external-secrets/clustersecretstore-onepassword.yaml
+++ b/chonchon/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.cp.lsst.org
+      vaults:
+        "k8s cp": 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/chonchon/external-secrets/external-secrets.sh
+++ b/chonchon/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/chonchon/external-secrets/fetch-credentials.sh
+++ b/chonchon/external-secrets/fetch-credentials.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 ONEPASS_TOKEN="$(op item get "connect.cp.lsst.org Access Token: chonchon.cp.lsst.org" --fields credential)"
 
 cat > secret-onepassword-token.yaml << END

--- a/chonchon/external-secrets/fetch-credentials.sh
+++ b/chonchon/external-secrets/fetch-credentials.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+ONEPASS_TOKEN="$(op item get "connect.cp.lsst.org Access Token: chonchon.cp.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/chonchon/rke/.gitignore
+++ b/chonchon/rke/.gitignore
@@ -1,1 +1,3 @@
-../.././template/rke/.gitignore
+cluster.rkestate
+kube_config_cluster.yml
+*.tar.gz

--- a/gaw/external-secrets/.gitignore
+++ b/gaw/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/gaw/external-secrets/README.md
+++ b/gaw/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/gaw/external-secrets/clustersecretstore-onepassword.yaml
+++ b/gaw/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.ls.lsst.org
+      vaults:
+        ls: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/gaw/external-secrets/external-secrets.sh
+++ b/gaw/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/gaw/external-secrets/fetch-credentials.sh
+++ b/gaw/external-secrets/fetch-credentials.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
+ONEPASS_TOKEN="$(op item get "connect.ls.lsst.org Access Token: gaw.ls.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/gaw/rke/.gitignore
+++ b/gaw/rke/.gitignore
@@ -1,1 +1,3 @@
-../.././template/rke/.gitignore
+cluster.rkestate
+kube_config_cluster.yml
+*.tar.gz

--- a/konkong/external-secrets/.gitignore
+++ b/konkong/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/konkong/external-secrets/README.md
+++ b/konkong/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/konkong/external-secrets/clustersecretstore-onepassword.yaml
+++ b/konkong/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.ls.lsst.org
+      vaults:
+        ls: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/konkong/external-secrets/external-secrets.sh
+++ b/konkong/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/konkong/external-secrets/fetch-credentials.sh
+++ b/konkong/external-secrets/fetch-credentials.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 ONEPASS_TOKEN="$(op item get "connect.ls.lsst.org Access Token: konkong.ls.lsst.org" --fields credential)"
 
 cat > secret-onepassword-token.yaml << END

--- a/konkong/external-secrets/fetch-credentials.sh
+++ b/konkong/external-secrets/fetch-credentials.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+ONEPASS_TOKEN="$(op item get "connect.ls.lsst.org Access Token: konkong.ls.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/kueyen/external-secrets/.gitignore
+++ b/kueyen/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/kueyen/external-secrets/README.md
+++ b/kueyen/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/kueyen/external-secrets/clustersecretstore-onepassword.yaml
+++ b/kueyen/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.dev.lsst.org
+      vaults:
+        Dev: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/kueyen/external-secrets/external-secrets.sh
+++ b/kueyen/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/kueyen/external-secrets/fetch-credentials.sh
+++ b/kueyen/external-secrets/fetch-credentials.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+ONEPASS_TOKEN="$(op item get "connect.dev.lsst.org Access Token: kueyen.dev.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/kueyen/external-secrets/fetch-credentials.sh
+++ b/kueyen/external-secrets/fetch-credentials.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 ONEPASS_TOKEN="$(op item get "connect.dev.lsst.org Access Token: kueyen.dev.lsst.org" --fields credential)"
 
 cat > secret-onepassword-token.yaml << END

--- a/kueyen/rke/.gitignore
+++ b/kueyen/rke/.gitignore
@@ -1,1 +1,3 @@
-../.././template/rke/.gitignore
+cluster.rkestate
+kube_config_cluster.yml
+*.tar.gz

--- a/luan/external-secrets/.gitignore
+++ b/luan/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/luan/external-secrets/README.md
+++ b/luan/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/luan/external-secrets/clustersecretstore-onepassword.yaml
+++ b/luan/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.ls.lsst.org
+      vaults:
+        ls: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/luan/external-secrets/external-secrets.sh
+++ b/luan/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/luan/external-secrets/fetch-credentials.sh
+++ b/luan/external-secrets/fetch-credentials.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+ONEPASS_TOKEN="$(op item get "connect.ls.lsst.org Access Token: luan.ls.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/luan/external-secrets/fetch-credentials.sh
+++ b/luan/external-secrets/fetch-credentials.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 ONEPASS_TOKEN="$(op item get "connect.ls.lsst.org Access Token: luan.ls.lsst.org" --fields credential)"
 
 cat > secret-onepassword-token.yaml << END

--- a/luan/rke/.gitignore
+++ b/luan/rke/.gitignore
@@ -1,1 +1,3 @@
-../.././template/rke/.gitignore
+cluster.rkestate
+kube_config_cluster.yml
+*.tar.gz

--- a/lukay/external-secrets/.gitignore
+++ b/lukay/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/lukay/external-secrets/README.md
+++ b/lukay/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/lukay/external-secrets/clustersecretstore-onepassword.yaml
+++ b/lukay/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.cp.lsst.org
+      vaults:
+        "k8s cp": 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/lukay/external-secrets/external-secrets.sh
+++ b/lukay/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/lukay/external-secrets/fetch-credentials.sh
+++ b/lukay/external-secrets/fetch-credentials.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 ONEPASS_TOKEN="$(op item get "connect.cp.lsst.org Access Token: lukay.cp.lsst.org" --fields credential)"
 
 cat > secret-onepassword-token.yaml << END

--- a/lukay/external-secrets/fetch-credentials.sh
+++ b/lukay/external-secrets/fetch-credentials.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+ONEPASS_TOKEN="$(op item get "connect.cp.lsst.org Access Token: lukay.cp.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/lukay/rke/.gitignore
+++ b/lukay/rke/.gitignore
@@ -1,1 +1,3 @@
-../.././template/rke/.gitignore
+cluster.rkestate
+kube_config_cluster.yml
+*.tar.gz

--- a/manke/external-secrets/.gitignore
+++ b/manke/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/manke/external-secrets/README.md
+++ b/manke/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/manke/external-secrets/clustersecretstore-onepassword.yaml
+++ b/manke/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.ls.lsst.org
+      vaults:
+        ls: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/manke/external-secrets/external-secrets.sh
+++ b/manke/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/manke/external-secrets/fetch-credentials.sh
+++ b/manke/external-secrets/fetch-credentials.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 ONEPASS_TOKEN="$(op item get "connect.ls.lsst.org Access Token: manke.ls.lsst.org" --fields credential)"
 
 cat > secret-onepassword-token.yaml << END

--- a/manke/external-secrets/fetch-credentials.sh
+++ b/manke/external-secrets/fetch-credentials.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+ONEPASS_TOKEN="$(op item get "connect.ls.lsst.org Access Token: manke.ls.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/namkueyen/external-secrets/.gitignore
+++ b/namkueyen/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/namkueyen/external-secrets/README.md
+++ b/namkueyen/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/namkueyen/external-secrets/clustersecretstore-onepassword.yaml
+++ b/namkueyen/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.dev.lsst.org
+      vaults:
+        Dev: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/namkueyen/external-secrets/external-secrets.sh
+++ b/namkueyen/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/namkueyen/external-secrets/fetch-credentials.sh
+++ b/namkueyen/external-secrets/fetch-credentials.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+ONEPASS_TOKEN="$(op item get "connect.dev.lsst.org Access Token: namkueyen.dev.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/namkueyen/external-secrets/fetch-credentials.sh
+++ b/namkueyen/external-secrets/fetch-credentials.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 ONEPASS_TOKEN="$(op item get "connect.dev.lsst.org Access Token: namkueyen.dev.lsst.org" --fields credential)"
 
 cat > secret-onepassword-token.yaml << END

--- a/pillan/external-secrets/.gitignore
+++ b/pillan/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/pillan/external-secrets/README.md
+++ b/pillan/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/pillan/external-secrets/clustersecretstore-onepassword.yaml
+++ b/pillan/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.tu.lsst.org
+      vaults:
+        tu: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/pillan/external-secrets/external-secrets.sh
+++ b/pillan/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/pillan/external-secrets/fetch-credentials.sh
+++ b/pillan/external-secrets/fetch-credentials.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 ONEPASS_TOKEN="$(op item get "connect.tu.lsst.org Access Token: pillan.tu.lsst.org" --fields credential)"
 
 cat > secret-onepassword-token.yaml << END

--- a/pillan/external-secrets/fetch-credentials.sh
+++ b/pillan/external-secrets/fetch-credentials.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+ONEPASS_TOKEN="$(op item get "connect.tu.lsst.org Access Token: pillan.tu.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/pillan/rke/.gitignore
+++ b/pillan/rke/.gitignore
@@ -1,1 +1,3 @@
-../.././template/rke/.gitignore
+cluster.rkestate
+kube_config_cluster.yml
+*.tar.gz

--- a/rancher.cp/external-secrets/.gitignore
+++ b/rancher.cp/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/rancher.cp/external-secrets/README.md
+++ b/rancher.cp/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/rancher.cp/external-secrets/clustersecretstore-onepassword.yaml
+++ b/rancher.cp/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.cp.lsst.org
+      vaults:
+        "k8s cp": 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/rancher.cp/external-secrets/external-secrets.sh
+++ b/rancher.cp/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/rancher.cp/external-secrets/fetch-credentials.sh
+++ b/rancher.cp/external-secrets/fetch-credentials.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+ONEPASS_TOKEN="$(op item get "connect.cp.lsst.org Access Token: rancher.cp.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/rancher.cp/external-secrets/fetch-credentials.sh
+++ b/rancher.cp/external-secrets/fetch-credentials.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 ONEPASS_TOKEN="$(op item get "connect.cp.lsst.org Access Token: rancher.cp.lsst.org" --fields credential)"
 
 cat > secret-onepassword-token.yaml << END

--- a/rancher.cp/external-secrets/test/externalsecret-test1.yaml
+++ b/rancher.cp/external-secrets/test/externalsecret-test1.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: test1
+  namespace: external-secrets
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+  data:
+  - secretKey: user
+    remoteRef:
+      key: it-dns-cp (aws)
+      property: username
+  - secretKey: pass
+    remoteRef:
+      key: it-dns-cp (aws)
+      property: password

--- a/rancher.cp/onepassword/.gitignore
+++ b/rancher.cp/onepassword/.gitignore
@@ -1,0 +1,1 @@
+1password-credentials.json

--- a/rancher.cp/onepassword/README.md
+++ b/rancher.cp/onepassword/README.md
@@ -1,0 +1,1 @@
+../../template/onepassword/README.md

--- a/rancher.cp/onepassword/fetch-credentials.sh
+++ b/rancher.cp/onepassword/fetch-credentials.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+op read "op://1pass connect/connect.cp.lsst.org Credentials File/1password-credentials.json" --out-file 1password-credentials.json

--- a/rancher.cp/onepassword/fetch-credentials.sh
+++ b/rancher.cp/onepassword/fetch-credentials.sh
@@ -2,5 +2,7 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 op read "op://1pass connect/connect.cp.lsst.org Credentials File/1password-credentials.json" --out-file 1password-credentials.json

--- a/rancher.cp/onepassword/onepassword-connect.sh
+++ b/rancher.cp/onepassword/onepassword-connect.sh
@@ -1,0 +1,1 @@
+../../template/onepassword/onepassword-connect.sh

--- a/rancher.cp/rke/.gitignore
+++ b/rancher.cp/rke/.gitignore
@@ -1,1 +1,3 @@
-../.././template/rke/.gitignore
+cluster.rkestate
+kube_config_cluster.yml
+*.tar.gz

--- a/rancher.dev/external-secrets/.gitignore
+++ b/rancher.dev/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/rancher.dev/external-secrets/README.md
+++ b/rancher.dev/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/rancher.dev/external-secrets/clustersecretstore-onepassword.yaml
+++ b/rancher.dev/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.dev.lsst.org
+      vaults:
+        Dev: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/rancher.dev/external-secrets/external-secrets.sh
+++ b/rancher.dev/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/rancher.dev/external-secrets/fetch-credentials.sh
+++ b/rancher.dev/external-secrets/fetch-credentials.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 ONEPASS_TOKEN="$(op item get "connect.dev.lsst.org Access Token: rancher.dev.lsst.org" --fields credential)"
 
 cat > secret-onepassword-token.yaml << END

--- a/rancher.dev/external-secrets/fetch-credentials.sh
+++ b/rancher.dev/external-secrets/fetch-credentials.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+ONEPASS_TOKEN="$(op item get "connect.dev.lsst.org Access Token: rancher.dev.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/rancher.dev/external-secrets/test/externalsecret-test1.yaml
+++ b/rancher.dev/external-secrets/test/externalsecret-test1.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: test1
+  namespace: external-secrets
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+  data:
+  - secretKey: user
+    remoteRef:
+      key: it-dns-dev (aws)
+      property: username
+  - secretKey: pass
+    remoteRef:
+      key: it-dns-dev (aws)
+      property: password

--- a/rancher.dev/onepassword/.gitignore
+++ b/rancher.dev/onepassword/.gitignore
@@ -1,0 +1,1 @@
+1password-credentials.json

--- a/rancher.dev/onepassword/README.md
+++ b/rancher.dev/onepassword/README.md
@@ -1,0 +1,1 @@
+../../template/onepassword/README.md

--- a/rancher.dev/onepassword/fetch-credentials.sh
+++ b/rancher.dev/onepassword/fetch-credentials.sh
@@ -2,5 +2,7 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 op read "op://1pass connect/connect.dev.lsst.org Credentials File/1password-credentials.json" --out-file 1password-credentials.json

--- a/rancher.dev/onepassword/fetch-credentials.sh
+++ b/rancher.dev/onepassword/fetch-credentials.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+op read "op://1pass connect/connect.dev.lsst.org Credentials File/1password-credentials.json" --out-file 1password-credentials.json

--- a/rancher.dev/onepassword/onepassword-connect.sh
+++ b/rancher.dev/onepassword/onepassword-connect.sh
@@ -1,0 +1,1 @@
+../../template/onepassword/onepassword-connect.sh

--- a/rancher.dev/onepassword/values.yaml
+++ b/rancher.dev/onepassword/values.yaml
@@ -1,0 +1,17 @@
+---
+connect:
+  ingress:
+    enabled: true
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt
+      kubernetes.io/ingress.class: nginx
+    hosts:
+      - host: connect.dev.lsst.org
+        paths:
+          - /
+    pathType: Prefix
+    tls:
+      - secretName: connect-ingress-tls
+        hosts:
+          - connect.dev.lsst.org
+  serviceType: ClusterIP

--- a/rancher.ls/external-secrets/.gitignore
+++ b/rancher.ls/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/rancher.ls/external-secrets/README.md
+++ b/rancher.ls/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/rancher.ls/external-secrets/clustersecretstore-onepassword.yaml
+++ b/rancher.ls/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.ls.lsst.org
+      vaults:
+        ls: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/rancher.ls/external-secrets/external-secrets.sh
+++ b/rancher.ls/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/rancher.ls/external-secrets/fetch-credentials.sh
+++ b/rancher.ls/external-secrets/fetch-credentials.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+ONEPASS_TOKEN="$(op item get "connect.ls.lsst.org Access Token: rancher.ls.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/rancher.ls/external-secrets/fetch-credentials.sh
+++ b/rancher.ls/external-secrets/fetch-credentials.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 ONEPASS_TOKEN="$(op item get "connect.ls.lsst.org Access Token: rancher.ls.lsst.org" --fields credential)"
 
 cat > secret-onepassword-token.yaml << END

--- a/rancher.ls/external-secrets/test/externalsecret-test1.yaml
+++ b/rancher.ls/external-secrets/test/externalsecret-test1.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: test1
+  namespace: external-secrets
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+  data:
+  - secretKey: user
+    remoteRef:
+      key: it-dns-ls (aws)
+      property: username
+  - secretKey: pass
+    remoteRef:
+      key: it-dns-ls (aws)
+      property: password

--- a/rancher.ls/onepassword/.gitignore
+++ b/rancher.ls/onepassword/.gitignore
@@ -1,0 +1,1 @@
+1password-credentials.json

--- a/rancher.ls/onepassword/README.md
+++ b/rancher.ls/onepassword/README.md
@@ -1,0 +1,1 @@
+../../template/onepassword/README.md

--- a/rancher.ls/onepassword/fetch-credentials.sh
+++ b/rancher.ls/onepassword/fetch-credentials.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+op read "op://1pass connect/connect.ls.lsst.org Credentials File/1password-credentials.json" --out-file 1password-credentials.json

--- a/rancher.ls/onepassword/fetch-credentials.sh
+++ b/rancher.ls/onepassword/fetch-credentials.sh
@@ -2,5 +2,7 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 op read "op://1pass connect/connect.ls.lsst.org Credentials File/1password-credentials.json" --out-file 1password-credentials.json

--- a/rancher.ls/onepassword/onepassword-connect.sh
+++ b/rancher.ls/onepassword/onepassword-connect.sh
@@ -1,0 +1,1 @@
+../../template/onepassword/onepassword-connect.sh

--- a/rancher.ls/rke/.gitignore
+++ b/rancher.ls/rke/.gitignore
@@ -1,1 +1,3 @@
-../.././template/rke/.gitignore
+cluster.rkestate
+kube_config_cluster.yml
+*.tar.gz

--- a/rancher.tu/external-secrets/.gitignore
+++ b/rancher.tu/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/rancher.tu/external-secrets/README.md
+++ b/rancher.tu/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/rancher.tu/external-secrets/clustersecretstore-onepassword.yaml
+++ b/rancher.tu/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.tu.lsst.org
+      vaults:
+        tu: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/rancher.tu/external-secrets/external-secrets.sh
+++ b/rancher.tu/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/rancher.tu/external-secrets/fetch-credentials.sh
+++ b/rancher.tu/external-secrets/fetch-credentials.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 ONEPASS_TOKEN="$(op item get "connect.tu.lsst.org Access Token: rancher.tu.lsst.org" --fields credential)"
 
 cat > secret-onepassword-token.yaml << END

--- a/rancher.tu/external-secrets/fetch-credentials.sh
+++ b/rancher.tu/external-secrets/fetch-credentials.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+ONEPASS_TOKEN="$(op item get "connect.tu.lsst.org Access Token: rancher.tu.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/rancher.tu/external-secrets/test/externalsecret-test1.yaml
+++ b/rancher.tu/external-secrets/test/externalsecret-test1.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: test1
+  namespace: external-secrets
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner
+  data:
+  - secretKey: user
+    remoteRef:
+      key: it-dns-tu (aws)
+      property: username
+  - secretKey: pass
+    remoteRef:
+      key: it-dns-tu (aws)
+      property: password

--- a/rancher.tu/onepassword/.gitignore
+++ b/rancher.tu/onepassword/.gitignore
@@ -1,0 +1,1 @@
+1password-credentials.json

--- a/rancher.tu/onepassword/README.md
+++ b/rancher.tu/onepassword/README.md
@@ -1,0 +1,1 @@
+../../template/onepassword/README.md

--- a/rancher.tu/onepassword/fetch-credentials.sh
+++ b/rancher.tu/onepassword/fetch-credentials.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+op read "op://1pass connect/connect.tu.lsst.org Credentials File/1password-credentials.json" --out-file 1password-credentials.json

--- a/rancher.tu/onepassword/fetch-credentials.sh
+++ b/rancher.tu/onepassword/fetch-credentials.sh
@@ -2,5 +2,7 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 op read "op://1pass connect/connect.tu.lsst.org Credentials File/1password-credentials.json" --out-file 1password-credentials.json

--- a/rancher.tu/onepassword/onepassword-connect.sh
+++ b/rancher.tu/onepassword/onepassword-connect.sh
@@ -1,0 +1,1 @@
+../../template/onepassword/onepassword-connect.sh

--- a/rancher.tu/rke/.gitignore
+++ b/rancher.tu/rke/.gitignore
@@ -1,1 +1,3 @@
-../../template/rke/.gitignore
+cluster.rkestate
+kube_config_cluster.yml
+*.tar.gz

--- a/ruka/external-secrets/.gitignore
+++ b/ruka/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/ruka/external-secrets/README.md
+++ b/ruka/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/ruka/external-secrets/clustersecretstore-onepassword.yaml
+++ b/ruka/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.dev.lsst.org
+      vaults:
+        Dev: 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/ruka/external-secrets/external-secrets.sh
+++ b/ruka/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/ruka/external-secrets/fetch-credentials.sh
+++ b/ruka/external-secrets/fetch-credentials.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+ONEPASS_TOKEN="$(op item get "connect.dev.lsst.org Access Token: ruka.dev.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/ruka/rke/.gitignore
+++ b/ruka/rke/.gitignore
@@ -1,1 +1,3 @@
-../.././template/rke/.gitignore
+cluster.rkestate
+kube_config_cluster.yml
+*.tar.gz

--- a/template/external-secrets/.gitignore
+++ b/template/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/template/external-secrets/README.md
+++ b/template/external-secrets/README.md
@@ -1,0 +1,9 @@
+external-secrets
+================
+
+Deployment
+----------
+
+Run the `fetch-credentials.sh` script to download the 1pass access token.  Note the `op` CLI must be installed and configured.
+
+Once the `1password-credentials.json` file is present, run the `external-secrets.sh` script.

--- a/template/external-secrets/external-secrets.sh
+++ b/template/external-secrets/external-secrets.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -ex
+
+helm repo add external-secrets https://charts.external-secrets.io
+helm repo update
+
+helm upgrade --install \
+  external-secrets external-secrets/external-secrets \
+  --create-namespace --namespace external-secrets \
+  --version v0.9.11 \
+  --atomic
+
+kubectl apply -f secret-onepassword-token.yaml
+kubectl apply -f clustersecretstore-onepassword.yaml

--- a/template/onepassword/.gitignore
+++ b/template/onepassword/.gitignore
@@ -1,0 +1,1 @@
+1password-credentials.json

--- a/template/onepassword/README.md
+++ b/template/onepassword/README.md
@@ -1,0 +1,9 @@
+onepassword
+===========
+
+Deployment
+----------
+
+Run the `fetch-credentials.sh` script to download the 1pass access token.  Note the `op` CLI must be installed and configured.
+
+Once the `1password-credentials.json` file is present, run the `onepassword-connect.sh` script.

--- a/template/onepassword/onepassword-connect.sh
+++ b/template/onepassword/onepassword-connect.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -ex
+
+helm repo add onepassword-connect https://1password.github.io/connect-helm-charts
+helm repo update
+
+helm upgrade --install \
+  onepassword-connect onepassword-connect/connect \
+  --create-namespace --namespace onepassword-connect \
+  --version v1.14.0 \
+  --atomic \
+  --set-file connect.credentials=1password-credentials.json \
+  -f ./values.yaml

--- a/yagan/external-secrets/.gitignore
+++ b/yagan/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/yagan/external-secrets/README.md
+++ b/yagan/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/yagan/external-secrets/clustersecretstore-onepassword.yaml
+++ b/yagan/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.cp.lsst.org
+      vaults:
+        "k8s cp": 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/yagan/external-secrets/external-secrets.sh
+++ b/yagan/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/yagan/external-secrets/fetch-credentials.sh
+++ b/yagan/external-secrets/fetch-credentials.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+ONEPASS_TOKEN="$(op item get "connect.cp.lsst.org Access Token: yagan.cp.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/yagan/external-secrets/fetch-credentials.sh
+++ b/yagan/external-secrets/fetch-credentials.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 ONEPASS_TOKEN="$(op item get "connect.cp.lsst.org Access Token: yagan.cp.lsst.org" --fields credential)"
 
 cat > secret-onepassword-token.yaml << END

--- a/yagan/rke/.gitignore
+++ b/yagan/rke/.gitignore
@@ -1,1 +1,3 @@
-../.././template/rke/.gitignore
+cluster.rkestate
+kube_config_cluster.yml
+*.tar.gz

--- a/yepun/external-secrets/.gitignore
+++ b/yepun/external-secrets/.gitignore
@@ -1,0 +1,1 @@
+secret-onepassword-token.yaml

--- a/yepun/external-secrets/README.md
+++ b/yepun/external-secrets/README.md
@@ -1,0 +1,1 @@
+../../template/external-secrets/README.md

--- a/yepun/external-secrets/clustersecretstore-onepassword.yaml
+++ b/yepun/external-secrets/clustersecretstore-onepassword.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+  namespace: external-secrets
+spec:
+  provider:
+    onepassword:
+      connectHost: https://connect.cp.lsst.org
+      vaults:
+        "k8s cp": 1
+      auth:
+        secretRef:
+          connectTokenSecretRef:
+            name: onepassword-connect-token
+            key: token
+            namespace: external-secrets

--- a/yepun/external-secrets/external-secrets.sh
+++ b/yepun/external-secrets/external-secrets.sh
@@ -1,0 +1,1 @@
+../../template/external-secrets/external-secrets.sh

--- a/yepun/external-secrets/fetch-credentials.sh
+++ b/yepun/external-secrets/fetch-credentials.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+eval "$(op signin)"
+ONEPASS_TOKEN="$(op item get "connect.cp.lsst.org Access Token: yepun.cp.lsst.org" --fields credential)"
+
+cat > secret-onepassword-token.yaml << END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: onepassword-connect-token
+  namespace: external-secrets
+type: Opaque
+stringData:
+  token: ${ONEPASS_TOKEN}
+END

--- a/yepun/external-secrets/fetch-credentials.sh
+++ b/yepun/external-secrets/fetch-credentials.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-eval "$(op signin)"
+if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
+  eval "$(op signin)"
+fi
 ONEPASS_TOKEN="$(op item get "connect.cp.lsst.org Access Token: yepun.cp.lsst.org" --fields credential)"
 
 cat > secret-onepassword-token.yaml << END

--- a/yepun/rke/.gitignore
+++ b/yepun/rke/.gitignore
@@ -1,1 +1,3 @@
-../.././template/rke/.gitignore
+cluster.rkestate
+kube_config_cluster.yml
+*.tar.gz


### PR DESCRIPTION
Note that installing external-secrets (and charts which it depends upon only on the rancher.* clusters) is a special case  / bootstraping and will continue to require the use of a shell script, env vars, and/or templating until secret inject is handled by a CI/CD tool.