### PR TITLE
(ayekan) deploy kyverno servicemonitor

### DIFF
--- a/ayekan/kyverno/kyverno.sh
+++ b/ayekan/kyverno/kyverno.sh
@@ -79,3 +79,4 @@ reportsController:
 EOF
 
 kubectl apply -f policies
+kubectl --namespace kyverno apply -f ./servicemonitor.yaml

--- a/ayekan/kyverno/servicemonitor.yaml
+++ b/ayekan/kyverno/servicemonitor.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kyverno-metrics
+  labels:
+    o11y.eu/monitor: enabled
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kyverno
+      app.kubernetes.io/instance: kyverno
+  endpoints:
+  - port: metrics-port
+    path: /metrics
+    honorLabels: false
+    scrapeTimeout: 10s
+    interval: 15s


### PR DESCRIPTION
Deploy the kyverno servicemonitor into ayekan. This allows prometheus to scrape kyverno metrics.