### PR TITLE
(ayekan) fix prometheus alerts for missing k8s components

### DIFF
--- a/ayekan/prometheus/values.yaml
+++ b/ayekan/prometheus/values.yaml
@@ -219,3 +219,11 @@ grafana:
           jsonData:
             handleGrafanaManagedAlerts: false
             implementation: prometheus
+
+# these components are not present in the Rancher clusters
+kubeScheduler:
+  enabled: false
+kubeProxy:
+  enabled: false
+kubeControllerManager:
+  enabled: false


### PR DESCRIPTION
Due to Rancher, some components are missing from their standard places in kubernetes and this triggers unactionable alerts from the prometheus stack.