### PR TITLE
(fleet/rook-ceph-conf) add rsphome export to pillan

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-rsphome.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-rsphome.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephFilesystem
+metadata:
+  name: rsphome
+  namespace: rook-ceph
+spec:
+  metadataPool:
+    failureDomain: host
+    replicated:
+      size: 3
+    quotas:
+      maxSize: 10Gi
+  dataPools:
+    - name: default
+      failureDomain: host
+      replicated:
+        size: 3
+      quotas:
+        maxSize: 25Gi
+    - name: ec
+      failureDomain: host
+      erasureCoded:
+        dataChunks: 4
+        codingChunks: 3
+      quotas:
+        maxSize: 250Gi
+  metadataServer:
+    activeCount: 3
+    activeStandby: true
+    resources:
+      limits:
+        cpu: "4"
+        memory: 4Gi
+      requests:
+        cpu: "4"
+        memory: 4Gi
+  preserveFilesystemOnDelete: false
+---
+apiVersion: ceph.rook.io/v1
+kind: CephNFS
+metadata:
+  name: rsphome
+  namespace: rook-ceph
+spec:
+  rados:
+    pool: rsphome-data0
+    # RADOS namespace where NFS client recovery data is stored in the pool.
+    namespace: nfs-ns
+  server:
+    active: 1
+    resources:
+      limits:
+        cpu: "3"
+        memory: 8Gi
+      requests:
+        cpu: "3"
+        memory: 8Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: rook-ceph-nfs
+    ceph_daemon_type: nfs
+    ceph_nfs: rsphome
+    instance: a
+    rook_cluster: rook-ceph
+  name: rook-ceph-nfs-rsphome
+  namespace: rook-ceph
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 140.252.147.199
+spec:
+  ports:
+    - name: nfs
+      port: 2049
+      protocol: TCP
+      targetPort: 2049
+  selector:
+    app: rook-ceph-nfs
+    ceph_daemon_type: nfs
+    ceph_nfs: rsphome
+    instance: a
+    rook_cluster: rook-ceph
+  type: LoadBalancer

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cm-cephcli.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cm-cephcli.yaml
@@ -38,6 +38,10 @@ data:
     ceph nfs export rm comcam /comcam
     ceph nfs export create cephfs comcam /comcam comcam
 
+    waitfornfs rsphome
+    ceph nfs export rm rsphome /rsphome
+    ceph nfs export create cephfs rsphome /rsphome rsphome /rsphome
+
     ceph mgr module enable rook
     ceph orch set backend rook
     ceph device monitoring on

--- a/fleet/lib/rook-ceph-demo/fleet.yaml
+++ b/fleet/lib/rook-ceph-demo/fleet.yaml
@@ -75,6 +75,9 @@ targetCustomizations:
             - name: project
               path: /project
               server: nfs-project.tu.lsst.org
+            - name: rsphome
+              path: /rsphome
+              server: nfs-rsphome.tu.lsst.org
             - name: scratch
               path: /scratch
               server: nfs-scratch.tu.lsst.org


### PR DESCRIPTION
forgot to merge the rsphome before so now it is been added to the fleet deployment