### PR TITLE
(pillan) fix cluster name in rancher: c-st7p2 -> pillan

### DIFF
--- a/fleet/lib/fleet-conf/overlays/tu/gitrepo-pillan.yaml
+++ b/fleet/lib/fleet-conf/overlays/tu/gitrepo-pillan.yaml
@@ -27,6 +27,6 @@ spec:
     - fleet/lib/cert-manager-conf
   targets:
     - name: pillan
-      clusterName: c-st7p2
+      clusterName: pillan
   correctDrift:
     enabled: false  # XXX do not enable because of rook

--- a/fleet/lib/metallb-conf/fleet.yaml
+++ b/fleet/lib/metallb-conf/fleet.yaml
@@ -34,7 +34,7 @@ targetCustomizations:
       overlays:
         - ruka
   - name: pillan
-    clusterName: c-st7p2
+    clusterName: pillan
     yaml:
       overlays:
         - pillan

--- a/fleet/lib/metallb-demo/fleet.yaml
+++ b/fleet/lib/metallb-demo/fleet.yaml
@@ -20,7 +20,7 @@ targetCustomizations:
           - default
           - lhn
   - name: pillan
-    clusterName: c-st7p2
+    clusterName: pillan
     helm:
       values:
         pools:

--- a/fleet/lib/multus-conf/fleet.yaml
+++ b/fleet/lib/multus-conf/fleet.yaml
@@ -24,7 +24,7 @@ targetCustomizations:
       overlays:
         - ruka
   - name: pillan
-    clusterName: c-st7p2
+    clusterName: pillan
     yaml:
       overlays:
         - pillan

--- a/fleet/lib/multus-demo/fleet.yaml
+++ b/fleet/lib/multus-demo/fleet.yaml
@@ -25,7 +25,7 @@ targetCustomizations:
         networks:
           - lhn
   - name: pillan
-    clusterName: c-st7p2
+    clusterName: pillan
     helm:
       values:
         networks:

--- a/fleet/lib/rook-ceph-cluster/fleet.yaml
+++ b/fleet/lib/rook-ceph-cluster/fleet.yaml
@@ -72,7 +72,7 @@ targetCustomizations:
       valuesFiles:
         - overlays/ruka/values.yaml
   - name: pillan
-    clusterName: c-st7p2
+    clusterName: pillan
     helm:
       valuesFiles:
         - overlays/pillan/values.yaml

--- a/fleet/lib/rook-ceph-conf/fleet.yaml
+++ b/fleet/lib/rook-ceph-conf/fleet.yaml
@@ -56,7 +56,7 @@ targetCustomizations:
           ruka:
             enabled: true
   - name: pillan
-    clusterName: c-st7p2
+    clusterName: pillan
     helm:
       values:
         subchart:

--- a/fleet/lib/rook-ceph-demo/Chart.yaml
+++ b/fleet/lib/rook-ceph-demo/Chart.yaml
@@ -8,5 +8,5 @@ appVersion: 0.0.0
 dependencies:
   - name: pvc
     condition: pvc.enabled
-  - name: nfs-auxtel
-    condition: nfs-auxtel.enabled
+  - name: nfs
+    condition: nfs.enabled

--- a/fleet/lib/rook-ceph-demo/fleet.yaml
+++ b/fleet/lib/rook-ceph-demo/fleet.yaml
@@ -56,7 +56,7 @@ targetCustomizations:
               path: /auxtel
               server: 139.229.134.151
   - name: pillan
-    clusterName: c-st7p2
+    clusterName: pillan
     helm:
       values:
         pvc:
@@ -104,7 +104,7 @@ targetCustomizations:
         pvc:
           enabled: true
   - name: manke
-    clusterName: c-st7p2
+    clusterName: manke
     helm:
       values:
         pvc:


### PR DESCRIPTION
pillan was deleted from and re-imported into rancher.tu.lsst.org in order to fix the cluster name.