### PR TITLE
(pillan) add o11y rgw

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstore-o11y.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstore-o11y.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStore
+metadata:
+  name: o11y
+  namespace: rook-ceph
+spec:
+  metadataPool:
+    failureDomain: host
+    replicated:
+      size: 3
+    quotas:
+      maxSize: 10Gi
+  dataPool:
+    failureDomain: host
+    erasureCoded:
+      dataChunks: 4
+      codingChunks: 3
+    quotas:
+      maxSize: 1.00Ti
+  preservePoolsOnDelete: false
+  gateway:
+    sslCertificateRef:
+    port: 80
+    # securePort: 443
+    instances: 3
+    resources:
+      limits:
+        cpu: "4"
+        memory: 4Gi
+      requests:
+        cpu: "4"
+        memory: 4Gi
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: rook-ceph-rgw-ingress-o11y
+  namespace: rook-ceph
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-body-size: 1024m
+spec:
+  tls:
+  - hosts:
+    - s3.o11y.tu.lsst.org
+    secretName: rook-ceph-rgw-ingress-tls-o11y
+  rules:
+  - host: s3.o11y.tu.lsst.org
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: rook-ceph-rgw-o11y
+            port:
+              number: 80


### PR DESCRIPTION
Provision a new rgw instance accessible as s3.o11y.tu.lsst.org to sort metrics and logs for the TTS.