### PR TITLE
(rancher.*) fix missing onepassword chart values

### DIFF
--- a/rancher.cp/onepassword/values.yaml
+++ b/rancher.cp/onepassword/values.yaml
@@ -1,0 +1,17 @@
+---
+connect:
+  ingress:
+    enabled: true
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt
+      kubernetes.io/ingress.class: nginx
+    hosts:
+      - host: connect.cp.lsst.org
+        paths:
+          - /
+    pathType: Prefix
+    tls:
+      - secretName: connect-ingress-tls
+        hosts:
+          - connect.cp.lsst.org
+  serviceType: ClusterIP

--- a/rancher.ls/onepassword/values.yaml
+++ b/rancher.ls/onepassword/values.yaml
@@ -1,0 +1,17 @@
+---
+connect:
+  ingress:
+    enabled: true
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt
+      kubernetes.io/ingress.class: nginx
+    hosts:
+      - host: connect.ls.lsst.org
+        paths:
+          - /
+    pathType: Prefix
+    tls:
+      - secretName: connect-ingress-tls
+        hosts:
+          - connect.ls.lsst.org
+  serviceType: ClusterIP

--- a/rancher.tu/onepassword/values.yaml
+++ b/rancher.tu/onepassword/values.yaml
@@ -1,0 +1,17 @@
+---
+connect:
+  ingress:
+    enabled: true
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt
+      kubernetes.io/ingress.class: nginx
+    hosts:
+      - host: connect.tu.lsst.org
+        paths:
+          - /
+    pathType: Prefix
+    tls:
+      - secretName: connect-ingress-tls
+        hosts:
+          - connect.tu.lsst.org
+  serviceType: ClusterIP


### PR DESCRIPTION
These values.yaml files were unintentionally excluded by the root .gitignore.