### PR TITLE
Prometheus deployment rework

### DIFF
--- a/ayekan/exporters/blackbox-exporter/helm-values.yaml
+++ b/ayekan/exporters/blackbox-exporter/helm-values.yaml
@@ -14,10 +14,10 @@ serviceMonitor:
   selfMonitor:
     enabled: true
     labels:
-      monitor: enabled
+      lsst.io/monitor: "true"
   defaults:
     labels:
-      monitor: enabled
+      lsst.io/monitor: "true"
   targets:
     - name: googlehttpcheck
       url: https://google.com
@@ -25,8 +25,14 @@ serviceMonitor:
       interval: 60s
       module: http_2xx
 
+# TODO: Error: UPGRADE FAILED: release blackbox-exporter failed, and has been
+# rolled back due to atomic being set: failed to create resource: admission
+# webhook "prometheusrulemutate.monitoring.coreos.com" denied the request: Cannot
+# unmarshal rules from spec
 prometheusRule:
   enabled: false
+  labels:
+    lsst.io/discover: "true"
 
 extraConfigmapMounts: []
 extraSecretMounts: []

--- a/ayekan/exporters/deploy-exporters.sh
+++ b/ayekan/exporters/deploy-exporters.sh
@@ -28,6 +28,5 @@ helm upgrade --install blackbox-exporter prometheus-community/prometheus-blackbo
      --version "8.4.0" \
      -f ./blackbox-exporter/helm-values.yaml
 
-# kminion - kafka exporter
-kubectl --namespace ${NAMESPACE=} apply -f kminion/config.yaml
-kubectl --namespace ${NAMESPACE=} apply -f kminion/deployment.yaml
+# puppetdb exporter
+kubectl --namespace ${NAMESPACE=} apply -f puppetdb-exporter/deployment.yaml

--- a/ayekan/exporters/puppetdb-exporter/deployment.yaml
+++ b/ayekan/exporters/puppetdb-exporter/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    o11y.eu/exporter: puppetdb
+    lsst.io/exporter: puppetdb
     environment: dev
   name: puppetdb-dev-exporter
   namespace: monitoring
@@ -44,6 +44,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: puppetdb-dev-exporter
+  namespace: monitoring
   labels:
     prometheus.io/exporter: puppetdb-exporter
     environment: dev
@@ -63,11 +64,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: puppetdb-dev-exporter
+  namespace: monitoring
   labels:
     prometheus.io/exporter: puppetdb-exporter
     environment: dev
-    o11y.eu/monitor: enabled
-    release: kube-prometheus-stack
+    lsst.io/monitor: "true"
 spec:
   selector:
     matchLabels:
@@ -84,6 +85,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: puppetdb-dev-exporter
+  namespace: monitoring
   labels:
     prometheus.io/exporter: puppetdb-exporter
     environment: dev
@@ -99,6 +101,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: puppetdb-dev-exporter
+  namespace: monitoring
   labels:
     prometheus.io/exporter: puppetdb-exporter
     environment: dev
@@ -107,9 +110,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    o11y.eu/exporter: puppetdb
+    lsst.io/exporter: puppetdb
     environment: ls
   name: puppetdb-ls-exporter
+  namespace: monitoring
 spec:
   replicas: 1
   selector:
@@ -147,9 +151,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: puppetdb-ls-exporter
+  namespace: monitoring
   labels:
     prometheus.io/exporter: puppetdb-exporter
     environment: ls
+    lsst.io/monitor: "true"
 spec:
   type: ClusterIP
   ports:
@@ -166,11 +172,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: puppetdb-ls-exporter
+  namespace: monitoring
   labels:
     prometheus.io/exporter: puppetdb-exporter
     environment: ls
-    o11y.eu/monitor: enabled
-    release: kube-prometheus-stack
+    lsst.io/monitor: "true"
 spec:
   selector:
     matchLabels:
@@ -187,6 +193,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: puppetdb-ls-exporter
+  namespace: monitoring
   labels:
     prometheus.io/exporter: puppetdb-exporter
     environment: ls
@@ -202,6 +209,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: puppetdb-ls-exporter
+  namespace: monitoring
   labels:
     prometheus.io/exporter: puppetdb-exporter
     environment: ls

--- a/ayekan/exporters/snmp-exporter/helm-values.yaml
+++ b/ayekan/exporters/snmp-exporter/helm-values.yaml
@@ -18,6 +18,8 @@ extraArgs:
 
 serviceMonitor:
   enabled: true
+  selector:
+    lsst.io/monitor: "true"
 
 extraSecretMounts:
   - name: snmp-config

--- a/ayekan/prometheus/prometheus.sh
+++ b/ayekan/prometheus/prometheus.sh
@@ -6,6 +6,8 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 helm repo add kube-state-metrics https://kubernetes.github.io/kube-state-metrics
 helm repo update
 
+kubectl --namespace kube-prometheus-stack apply -f ./webhooks-secret.yaml
+
 helm upgrade --install \
   kube-prometheus-stack prometheus-community/kube-prometheus-stack \
   --create-namespace --namespace kube-prometheus-stack \

--- a/ayekan/prometheus/values.yaml
+++ b/ayekan/prometheus/values.yaml
@@ -216,7 +216,7 @@ alertmanager:
   alertmanagerSpec:
     externalUrl: https://alertmanager.ayekan.dev.lsst.org
     secrets:
-      - o11y-webhooks
+      - lsst-webhooks
     configMaps:
       - alertmanager-templates
   ingress:
@@ -239,7 +239,7 @@ alertmanager:
   config:
     global:
       resolve_timeout: 5m
-      slack_api_url_file: /etc/alertmanager/secrets/o11y-webhooks/o11y-slack
+      slack_api_url_file: /etc/alertmanager/secrets/lsst-webhooks/slack-test
     route:
       group_by: ["alertname", "namespace"]
       group_wait: 30s
@@ -297,7 +297,7 @@ alertmanager:
             text: '{{ template "slack.o11y.networkAlert" . }}'
       - name: "squadcast-test"
         webhook_configs:
-          - url_file: /etc/alertmanger/secrets/o11y-webhooks/o11y-squadcast
+          - url_file: /etc/alertmanager/secrets/lsst-webhooks/squadcast-example
     inhibit_rules:
       - source_matchers:
           - alertname = "InfoInhibitor"

--- a/ayekan/prometheus/values.yaml
+++ b/ayekan/prometheus/values.yaml
@@ -2,9 +2,9 @@
 commonLabels:
   lsst.io/author: "fbegyn"
 
-defaultRule:
+defaultRules:
   create: true
-  additionalLabels:
+  labels:
     lsst.io/rule: "true"
 
 prometheusOperator:

--- a/ayekan/prometheus/values.yaml
+++ b/ayekan/prometheus/values.yaml
@@ -1,17 +1,80 @@
 ---
+commonLabels:
+  lsst.io/author: "fbegyn"
+
+defaultRule:
+  create: true
+  additionalLabels:
+    lsst.io/rule: "true"
+
+prometheusOperator:
+  enabled: true
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
 prometheus:
   prometheusSpec:
     externalUrl: https://prometheus.ayekan.ls.lsst.org
     serviceMonitorNamespaceSelector:
       matchLabels:
-        o11y.eu/monitor: "enabled"
-    serviceMonitorSelectorNilUsesHelmValues: false
-    serviceMonitorSelector: {}
+        lsst.io/discover: "true"
+    serviceMonitorSelector:
+      matchLabels:
+        lsst.io/monitor: "true"
+    podMonitorNamespaceSelector:
+      matchLabels:
+        lsst.io/discover: "true"
+    podMonitorSelector:
+      matchLabels:
+        lsst.io/monitor: "true"
+    ruleNamespaceSelector:
+      matchLabels:
+        lsst.io/discover: "true"
+    ruleSelector:
+      matchLabels:
+        lsst.io/rule: "true"
+    scrapeConfigNamespaceSelector:
+      matchLabels:
+        lsst.io/discover: "true"
+    scrapeConfigSelector:
+      matchLabels:
+        lsst.io/scrape: "true"
+    probeNamespaceSelector:
+      matchLabels:
+        lsst.io/discover: "true"
+    probeSelector:
+      matchLabels:
+        lsst.io/probe: "true"
     configMaps:
       - prometheus-snmp-csv-network
+      - pdu-targets
     remoteWrite:
       - url: http://ayekan-mimir-gateway.mimir:80/api/v1/push
     additionalScrapeConfigs:
+      - job_name: node-exporter-dev
+        puppetdb_sd_configs:
+          - url: "http://puppetdb.dev.lsst.org:8080"
+            query: "resources { type = \"Class\" and title = \"Prometheus::Node_exporter\" }"
+            refresh_interval: "30s"
+            follow_redirects: true
+            include_parameters: true
+            enable_http2: true
+            port: 9100
+        relabel_configs: &puppet-node-exporter
+          - source_labels: [__meta_puppetdb_certname]
+            target_label: instance
+          - source_labels: [__meta_puppetdb_environment]
+            target_label: environment
+      - job_name: node-exporter-ls
+        puppetdb_sd_configs:
+          - url: "http://puppetdb.ls.lsst.org:8080"
+            query: "resources { type = \"Class\" and title = \"Prometheus::Node_exporter\" }"
+            refresh_interval: "30s"
+            follow_redirects: true
+            include_parameters: true
+            enable_http2: true
+            port: 9100
+        relabel_configs: *puppet-node-exporter
       - job_name: blackbox-ping-dev
         metrics_path: /probe
         params:
@@ -160,6 +223,9 @@ prometheus:
           - prometheus.ayekan.ls.lsst.org
 
 alertmanager:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
   alertmanagerSpec:
     externalUrl: https://alertmanager.ayekan.ls.lsst.org
     secrets:
@@ -233,6 +299,9 @@ alertmanager:
       - "/etc/alertmanager/config/*.tmpl"
 
 grafana:
+  serviceMonitor:
+    labels:
+      lsst.io/monitor: "true"
   persistence:
     enabled: true
   ingress:
@@ -253,9 +322,9 @@ grafana:
         hosts:
           - grafana.ayekan.ls.lsst.org
   sidecar:
-    alerts:
-      enabled: true
     dashboards:
+      enabled: true
+    datasources:
       enabled: true
   datasources:
     datasource.yaml:
@@ -294,3 +363,30 @@ kubeProxy:
   enabled: false
 kubeControllerManager:
   enabled: false
+
+# specify the needed label for the serviceMonitor
+kubeApiServer:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
+kubelet:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
+coreDns:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
+kubeDns:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
+kubeEtcd:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
+prometheus-node-exporter:
+  prometheus:
+    monitor:
+      additionalLabels:
+        lsst.io/monitor: "true"

--- a/ayekan/prometheus/values.yaml
+++ b/ayekan/prometheus/values.yaml
@@ -6,6 +6,8 @@ defaultRules:
   create: true
   labels:
     lsst.io/rule: "true"
+  additionalRuleLabels:
+    receivers: ",squadcast,"
 
 prometheusOperator:
   enabled: true
@@ -239,6 +241,7 @@ alertmanager:
       resolve_timeout: 5m
       slack_api_url_file: /etc/alertmanager/secrets/o11y-webhooks/o11y-slack
     route:
+      group_by: ["alertname", "namespace"]
       group_wait: 30s
       group_interval: 5m
       repeat_interval: 24h
@@ -252,15 +255,17 @@ alertmanager:
             - alertname = "Watchdog"
         - receiver: "squadcast-test"
           matchers:
-            - receiver =~ ".*,squadcast,.*"
+            - receivers =~ ".*,squadcast,.*"
           continue: true
         - receiver: slack-kube-test
           matchers:
             - alertname =~ "Kube.*"
         - receiver: slack-node-test
+          group_by: ["instance"]
           matchers:
             - alertname =~ "Node.*"
         - receiver: slack-network-test
+          group_by: ["instance"]
           matchers:
             - alertname =~ "Network.*"
     receivers:
@@ -271,25 +276,25 @@ alertmanager:
           - username: "ayekan-kube"
             channel: "#rubinobs-monitoring-test"
             send_resolved: true
-            text: '{{ template "slack.o11y.genericAlert" }}'
+            text: '{{ template "slack.o11y.genericAlert" . }}'
       - name: "slack-kube-test"
         slack_configs:
           - username: "ayekan-kube"
             channel: "#rubinobs-monitoring-test"
             send_resolved: true
-            text: '{{ template "slack.o11y.kubeAlert" }}'
+            text: '{{ template "slack.o11y.kubeAlert" . }}'
       - name: "slack-node-test"
         slack_configs:
           - username: "ayekan-nodes"
             channel: "#rubinobs-monitoring-test"
             send_resolved: true
-            text: '{{ template "slack.o11y.nodeAlert" }}'
+            text: '{{ template "slack.o11y.nodeAlert" . }}'
       - name: "slack-network-test"
         slack_configs:
           - username: "ayekan-network"
             channel: "#rubinobs-monitoring-test"
             send_resolved: true
-            text: '{{ template "slack.o11y.networkAlert" }}'
+            text: '{{ template "slack.o11y.networkAlert" . }}'
       - name: "squadcast-test"
         webhook_configs:
           - url_file: /etc/alertmanger/secrets/o11y-webhooks/o11y-squadcast

--- a/ayekan/prometheus/values.yaml
+++ b/ayekan/prometheus/values.yaml
@@ -14,7 +14,7 @@ prometheusOperator:
       lsst.io/monitor: "true"
 prometheus:
   prometheusSpec:
-    externalUrl: https://prometheus.ayekan.ls.lsst.org
+    externalUrl: https://prometheus.ayekan.dev.lsst.org
     serviceMonitorNamespaceSelector:
       matchLabels:
         lsst.io/discover: "true"
@@ -49,7 +49,7 @@ prometheus:
       - prometheus-snmp-csv-network
       - pdu-targets
     remoteWrite:
-      - url: http://ayekan-mimir-gateway.mimir:80/api/v1/push
+      - url: http://mimir-distributed-gateway.mimir:80/api/v1/push
     additionalScrapeConfigs:
       - job_name: node-exporter-dev
         puppetdb_sd_configs:
@@ -92,7 +92,7 @@ prometheus:
           - source_labels: [__param_target]
             target_label: instance
           - target_label: __address__
-            replacement: "blackbox-exporter-prometheus-blackbox-exporter.monitoring:9115"
+            replacement: "prometheus-blackbox-exporter.blackbox-exporter:9115"
       - job_name: blackbox-ping-ls
         metrics_path: /probe
         params:
@@ -113,7 +113,7 @@ prometheus:
         file_sd_configs:
           - files:
               - "/etc/prometheus/configmaps/prometheus-snmp-csv-network/snmp-csv-network.json"
-        relabel_configs:
+        relabel_configs: &network-snmp-relabel
           - source_labels: [__address__]
             target_label: __param_target
           - source_labels: [__meta_hostname]
@@ -121,7 +121,7 @@ prometheus:
           - source_labels: [__meta_network_function]
             target_label: network_function
           - target_label: __address__
-            replacement: "snmp-exporter-prometheus-snmp-exporter.monitoring:9116"
+            replacement: "prometheus-snmp-exporter.snmp-exporter:9116"
       - job_name: blackbox-csv-network
         metrics_path: /probe
         params:
@@ -137,7 +137,7 @@ prometheus:
           - source_labels: [__meta_network_function]
             target_label: network_function
           - target_label: __address__
-            replacement: "blackbox-exporter-prometheus-blackbox-exporter.monitoring:9115"
+            replacement: "prometheus-blackbox-exporter.blackbox-exporter:9115"
       - job_name: snmp-raritan-pdu
         metrics_path: /snmp
         params:
@@ -146,13 +146,13 @@ prometheus:
         file_sd_configs:
           - files:
               - "/etc/prometheus/configmaps/pdu-targets/pdu-targets.json"
-        relabel_configs:
+        relabel_configs: &snmp-relabel
           - source_labels: [__address__]
             target_label: __param_target
           - source_labels: [__meta_hostname]
             target_label: instance
           - target_label: __address__
-            replacement: "snmp-exporter-prometheus-snmp-exporter.monitoring:9116"
+            replacement: "prometheus-snmp-exporter.snmp-exporter:9116"
       - job_name: snmp-xups-public
         metrics_path: /snmp
         params:
@@ -163,13 +163,7 @@ prometheus:
               - 10.18.3.31
             labels:
               __meta_hostname: ups-01
-        relabel_configs:
-          - source_labels: [__address__]
-            target_label: __param_target
-          - source_labels: [__meta_hostname]
-            target_label: instance
-          - target_label: __address__
-            replacement: "snmp-exporter-prometheus-snmp-exporter.monitoring:9116"
+        relabel_configs: *snmp-relabel
       - job_name: snmp-xups
         metrics_path: /snmp
         params:
@@ -180,13 +174,7 @@ prometheus:
               - 10.18.3.62
             labels:
               __meta_hostname: ups-02
-        relabel_configs:
-          - source_labels: [__address__]
-            target_label: __param_target
-          - source_labels: [__meta_hostname]
-            target_label: instance
-          - target_label: __address__
-            replacement: "snmp-exporter-prometheus-snmp-exporter.monitoring:9116"
+        relabel_configs: *snmp-relabel
       - job_name: snmp-schneider-pm5xxx
         metrics_path: /snmp
         params:
@@ -197,13 +185,7 @@ prometheus:
               - 10.18.3.21
             labels:
               __meta_hostname: pdu-01
-        relabel_configs:
-          - source_labels: [__address__]
-            target_label: __param_target
-          - source_labels: [__meta_hostname]
-            target_label: instance
-          - target_label: __address__
-            replacement: "snmp-exporter-prometheus-snmp-exporter.monitoring:9116"
+        relabel_configs: *snmp-relabel
   ingress:
     enabled: true
     annotations:
@@ -216,20 +198,25 @@ prometheus:
       - /
     pathType: Prefix
     hosts:
-      - prometheus.ayekan.ls.lsst.org
+      - prometheus.ayekan.dev.lsst.org
     tls:
       - secretName: tls-prometheus-ingress
         hosts:
-          - prometheus.ayekan.ls.lsst.org
+          - prometheus.ayekan.dev.lsst.org
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
 
 alertmanager:
   serviceMonitor:
     additionalLabels:
       lsst.io/monitor: "true"
   alertmanagerSpec:
-    externalUrl: https://alertmanager.ayekan.ls.lsst.org
+    externalUrl: https://alertmanager.ayekan.dev.lsst.org
     secrets:
       - o11y-webhooks
+    configMaps:
+      - alertmanager-templates
   ingress:
     enabled: true
     annotations:
@@ -242,17 +229,16 @@ alertmanager:
       - /
     pathType: Prefix
     hosts:
-      - alertmanager.ayekan.ls.lsst.org
+      - alertmanager.ayekan.dev.lsst.org
     tls:
       - secretName: tls-alertmanager-ingress
         hosts:
-          - alertmanager.ayekan.ls.lsst.org
+          - alertmanager.ayekan.dev.lsst.org
   config:
     global:
       resolve_timeout: 5m
       slack_api_url_file: /etc/alertmanager/secrets/o11y-webhooks/o11y-slack
     route:
-      group_by: ["namespace", "cluster"]
       group_wait: 30s
       group_interval: 5m
       repeat_interval: 24h
@@ -268,14 +254,42 @@ alertmanager:
           matchers:
             - receiver =~ ".*,squadcast,.*"
           continue: true
+        - receiver: slack-kube-test
+          matchers:
+            - alertname =~ "Kube.*"
+        - receiver: slack-node-test
+          matchers:
+            - alertname =~ "Node.*"
+        - receiver: slack-network-test
+          matchers:
+            - alertname =~ "Network.*"
     receivers:
       - name: "null"
       - name: "watchdog"
       - name: "slack-test"
         slack_configs:
-          - username: "ayekan-prometheus"
+          - username: "ayekan-kube"
             channel: "#rubinobs-monitoring-test"
             send_resolved: true
+            text: '{{ template "slack.o11y.genericAlert" }}'
+      - name: "slack-kube-test"
+        slack_configs:
+          - username: "ayekan-kube"
+            channel: "#rubinobs-monitoring-test"
+            send_resolved: true
+            text: '{{ template "slack.o11y.kubeAlert" }}'
+      - name: "slack-node-test"
+        slack_configs:
+          - username: "ayekan-nodes"
+            channel: "#rubinobs-monitoring-test"
+            send_resolved: true
+            text: '{{ template "slack.o11y.nodeAlert" }}'
+      - name: "slack-network-test"
+        slack_configs:
+          - username: "ayekan-network"
+            channel: "#rubinobs-monitoring-test"
+            send_resolved: true
+            text: '{{ template "slack.o11y.networkAlert" }}'
       - name: "squadcast-test"
         webhook_configs:
           - url_file: /etc/alertmanger/secrets/o11y-webhooks/o11y-squadcast
@@ -296,7 +310,7 @@ alertmanager:
           - severity = "info"
         equal: ["alertname"]
     templates:
-      - "/etc/alertmanager/config/*.tmpl"
+      - "/etc/alertmanager/configmaps/alertmanager-templates/*.tmpl"
 
 grafana:
   serviceMonitor:
@@ -316,11 +330,11 @@ grafana:
       - /
     pathType: Prefix
     hosts:
-      - grafana.ayekan.ls.lsst.org
+      - grafana.ayekan.dev.lsst.org
     tls:
       - secretName: tls-grafana-ingress
         hosts:
-          - grafana.ayekan.ls.lsst.org
+          - grafana.ayekan.dev.lsst.org
   sidecar:
     dashboards:
       enabled: true
@@ -341,7 +355,7 @@ grafana:
         - name: Mimir
           type: prometheus
           uid: mimir
-          url: http://ayekan-mimir-gateway.mimir:80/prometheus
+          url: http://mimir-distributed-gateway.mimir:80/prometheus
           access: proxy
           isDefault: true
           jsonData:
@@ -390,3 +404,10 @@ prometheus-node-exporter:
     monitor:
       additionalLabels:
         lsst.io/monitor: "true"
+kube-state-metrics:
+  prometheus:
+    monitor:
+      additionalLabels:
+        lsst.io/monitor: "true"
+  selfMonitor:
+    enabled: true

--- a/ayekan/prometheus/webhooks-secret.yaml
+++ b/ayekan/prometheus/webhooks-secret.yaml
@@ -2,23 +2,18 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: o11y-webhooks
-  namespace: kube-stack-prometheus
+  name: lsst-webhooks
+  namespace: kube-prometheus-stack
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword
   data:
-    - secretKey: slackWebhookKey
+    - secretKey: slack-test
       remoteRef:
         key: "slack #rubinobs-monitoring-test webhook url"
         property: credential
-    - secretKey: squadcastWebhookKey
+    - secretKey: squadcast-example
       remoteRef:
         key: "squadcast prometheus service"
         property: credential
-  target:
-    template:
-      data:
-        o11y-slack: {{.slackWebhookKey}}
-        o11y-squadcast: {{.squadcastWebhookKey}}

--- a/fleet/lib/blackbox-exporter/fleet.yaml
+++ b/fleet/lib/blackbox-exporter/fleet.yaml
@@ -1,5 +1,7 @@
 ---
 defaultNamespace: &name blackbox-exporter
+namespaceLabels:
+  lsst.io/discover: "true"
 labels:
   bundle: *name
 helm:

--- a/fleet/lib/blackbox-exporter/values.yaml
+++ b/fleet/lib/blackbox-exporter/values.yaml
@@ -30,6 +30,10 @@ serviceMonitor:
 # rolled back due to atomic being set: failed to create resource: admission
 # webhook "prometheusrulemutate.monitoring.coreos.com" denied the request: Cannot
 # unmarshal rules from spec
+# This error happens due to the fact that the PrometheusRules from the blackbox
+# exporter chart seem to be uncompatible with the new CRD's from the prometheus
+# operator being deployed. It would be good to have these deployed as well but
+# currently we're temporary disabling them.
 prometheusRule:
   enabled: false
   labels:

--- a/fleet/lib/blackbox-exporter/values.yaml
+++ b/fleet/lib/blackbox-exporter/values.yaml
@@ -15,10 +15,10 @@ serviceMonitor:
   selfMonitor:
     enabled: true
     labels:
-      monitor: enabled
+      lsst.io/monitor: "true"
   defaults:
     labels:
-      monitor: enabled
+      lsst.io/monitor: "true"
   targets:
     - name: googlehttpcheck
       url: https://google.com
@@ -26,8 +26,14 @@ serviceMonitor:
       interval: 60s
       module: http_2xx
 
+# TODO: Error: UPGRADE FAILED: release blackbox-exporter failed, and has been
+# rolled back due to atomic being set: failed to create resource: admission
+# webhook "prometheusrulemutate.monitoring.coreos.com" denied the request: Cannot
+# unmarshal rules from spec
 prometheusRule:
   enabled: false
+  labels:
+    lsst.io/discover: "true"
 
 extraConfigmapMounts: []
 extraSecretMounts: []

--- a/fleet/lib/cert-manager-conf/fleet.yaml
+++ b/fleet/lib/cert-manager-conf/fleet.yaml
@@ -1,5 +1,7 @@
 ---
 defaultNamespace: cert-manager
+namespaceLabels:
+  lsst.io/discover: "true"
 labels:
   bundle: &name cert-manager-conf
 helm:

--- a/fleet/lib/cert-manager-crds/fleet.yaml
+++ b/fleet/lib/cert-manager-crds/fleet.yaml
@@ -1,5 +1,7 @@
 ---
 defaultNamespace: cert-manager
+namespaceLabels:
+  lsst.io/discover: "true"
 labels:
   bundle: &name cert-manager-crds
 # https://github.com/rancher/fleet/issues/1285

--- a/fleet/lib/cert-manager/fleet.yaml
+++ b/fleet/lib/cert-manager/fleet.yaml
@@ -1,5 +1,7 @@
 ---
 defaultNamespace: &name cert-manager
+namespaceLabels:
+  lsst.io/discover: "true"
 labels:
   bundle: *name
 helm:
@@ -9,6 +11,12 @@ helm:
   version: v1.12.2
   values:
     installCRDs: false
+    prometheus:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+        labels:
+          lsst.io/monitor: "true"
   waitForJobs: true
   timeoutSeconds: 900
   atomic: false

--- a/fleet/lib/cert-manager/fleet.yaml
+++ b/fleet/lib/cert-manager/fleet.yaml
@@ -13,7 +13,7 @@ helm:
     installCRDs: false
     prometheus:
       enabled: true
-      serviceMonitor:
+      servicemonitor:
         enabled: true
         labels:
           lsst.io/monitor: "true"

--- a/fleet/lib/external-secrets/fleet.yaml
+++ b/fleet/lib/external-secrets/fleet.yaml
@@ -3,7 +3,7 @@ defaultNamespace: &name external-secrets
 labels:
   bundle: *name
 namespaceLabels:
-  o11y.eu/monitor: enabled
+  lsst.io/discover: "true"
 helm:
   chart: *name
   releaseName: *name
@@ -15,6 +15,9 @@ helm:
   values:
     serviceMonitor:
       enabled: true
+      labels:
+        lsst.io/monitor: "true"
+
 dependsOn:
   - selector:
       matchLabels:

--- a/fleet/lib/ingress-nginx/fleet.yaml
+++ b/fleet/lib/ingress-nginx/fleet.yaml
@@ -18,7 +18,11 @@ helm:
           enabled: true
           additionalLabels:
             lsst.io/monitor: "true"
-        # TODO: handle error: cannot unmarshal rule from spec
+        # TODO: handle error: cannot unmarshal rule from spec This error happens
+        # due to the fact that the PrometheusRules from the blackbox exporter
+        # chart seem to be uncompatible with the new CRD's from the prometheus
+        # operator being deployed. It would be good to have these deployed as
+        # well but currently we're temporary disabling them.
         prometheusRule:
           enabled: false
           additionalLabels:

--- a/fleet/lib/ingress-nginx/fleet.yaml
+++ b/fleet/lib/ingress-nginx/fleet.yaml
@@ -19,7 +19,7 @@ helm:
           additionalLabels:
             lsst.io/monitor: "true"
         # TODO: handle error: cannot unmarshal rule from spec This error happens
-        # due to the fact that the PrometheusRules from the blackbox exporter
+        # due to the fact that the PrometheusRules from the nginx-ingress
         # chart seem to be uncompatible with the new CRD's from the prometheus
         # operator being deployed. It would be good to have these deployed as
         # well but currently we're temporary disabling them.

--- a/fleet/lib/ingress-nginx/fleet.yaml
+++ b/fleet/lib/ingress-nginx/fleet.yaml
@@ -18,8 +18,9 @@ helm:
           enabled: true
           additionalLabels:
             lsst.io/monitor: "true"
+        # TODO: handle error: cannot unmarshal rule from spec
         prometheusRule:
-          enabled: true
+          enabled: false
           additionalLabels:
             lsst.io/rule: "true"
     rbac:

--- a/fleet/lib/ingress-nginx/fleet.yaml
+++ b/fleet/lib/ingress-nginx/fleet.yaml
@@ -1,5 +1,7 @@
 ---
 defaultNamespace: &name ingress-nginx
+namespaceLabels:
+  lsst.io/discover: "true"
 labels:
   bundle: *name
 helm:
@@ -10,6 +12,16 @@ helm:
   values:
     controller:
       kind: DaemonSet
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+          additionalLabels:
+            lsst.io/monitor: "true"
+        prometheusRule:
+          enabled: true
+          additionalLabels:
+            lsst.io/rule: "true"
     rbac:
       create: true
   waitForJobs: true

--- a/fleet/lib/kube-prometheus-stack-pre/configmap-alertmanager-templates.yaml
+++ b/fleet/lib/kube-prometheus-stack-pre/configmap-alertmanager-templates.yaml
@@ -18,7 +18,7 @@ data:
     {{ define "slack.o11y.kube.text" }}
     *Alert:* {{ .GroupLabels.alertname }}
     *Site:* {{ .GroupLabels.site }}
-    *Kube cluster:* {{ .GroupLabels.k8s-cluster }}
+    *Kube cluster:* {{ .GroupLabels.kubecluster }}
     *Namespace:* {{ .GroupLabels.namespace }}
     *Summary:* {{ .CommonAnnotations.summary }}
     {{ template "__o11y_alert_list" . }}

--- a/fleet/lib/kube-prometheus-stack-pre/configmap-alertmanager-templates.yaml
+++ b/fleet/lib/kube-prometheus-stack-pre/configmap-alertmanager-templates.yaml
@@ -49,5 +49,5 @@ data:
       {{ range .Labels.SortedPairs -}}
       - *{{ .Name }}:* `{{ .Value }}`
       {{ end }}
-    {{- end }}
+    {{ end }}
     {{ end }}

--- a/fleet/lib/kube-prometheus-stack-pre/configmap-alertmanager-templates.yaml
+++ b/fleet/lib/kube-prometheus-stack-pre/configmap-alertmanager-templates.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager-templates
+data:
+  slack-generic-alert.tmpl: |
+    {{ define "slack.o11y.genericAlert" }}
+    *Alert:* {{ .GroupLabels.alertname }}
+    *Summary:* {{ .CommonAnnotations.summary }}
+    {{ range .Alerts -}}
+    - *Alert:* {{ .Labels.alertname }}
+      *Summary:* {{ .Annotations.summary }}
+      *Description:* {{ .Annotations.description }}
+      *Severity:* {{ .Labels.severity }}
+      *Time:* {{ .StartsAt.Format "2006-01-02 15:04:05 MST" }}
+      *Labels:*
+      {{ range .Labels.SortedPairs }} - *{{ .Name }}:* `{{ .Value }}`
+      {{ end }}
+    {{ end }}
+    {{ end }}
+  slack-kube-alert.tmpl: |
+    {{ define "slack.o11y.kubeAlert" }}
+    *Alert:* {{ .GroupLabels.alertname }}
+    *Namespace:* {{ .GroupLabels.namespace }}
+    *Summary:* {{ .CommonAnnotations.summary }}
+    {{ range .Alerts }}
+    - *Runbook:* {{ .Annotations.runbook_url }}
+      *Description:* {{ .Annotations.description }}
+      *Severity:* {{ .Labels.severity }}
+      *Time:* {{ .StartsAt.Format "2006-01-02 15:04:05 MST" }}
+      *Labels:*
+      {{ range .Labels.SortedPairs }} - *{{ .Name }}:* `{{ .Value }}`
+      {{ end }}
+    {{ end }}
+    {{ end }}
+  slack-network-alert.tmpl: |
+    {{ define "slack.o11y.networkAlert" }}
+    *Device:* {{ .GroupLabels.instance }}
+    *Alerts:*
+    {{ range .Alerts }}
+    - *Alert:* {{ .Labels.alertname }}
+      *Summary:* {{ .Annotations.summary }}
+      *Description:* {{ .Annotations.description }}
+      *Severity:* {{ .Labels.severity }}
+      *Time:* {{ .StartsAt.Format "2006-01-02 15:04:05 MST" }}
+      *Labels:*
+      {{ range .Labels.SortedPairs }} - *{{ .Name }}:* `{{ .Value }}`
+      {{ end }}
+    {{ end }}
+    {{ end }}
+  slack-node-alert.tmpl: |
+    {{ define "slack.o11y.nodeAlert" }}
+    *Instance:* {{ .GroupLabels.instance }}
+    *Alerts:*
+    {{ range .Alerts }}
+    - *Alert:* {{ .Labels.alertname }}
+      *Summary:* {{ .Annotations.summary }}
+      *Description:* {{ .Annotations.description }}
+      *Severity:* {{ .Labels.severity }}
+      *Time:* {{ .StartsAt.Format "2006-01-02 15:04:05 MST" }}
+    {{ end }}
+    {{ end }}

--- a/fleet/lib/kube-prometheus-stack-pre/configmap-alertmanager-templates.yaml
+++ b/fleet/lib/kube-prometheus-stack-pre/configmap-alertmanager-templates.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   slack-generic-alert.tmpl: |
     {{ define "slack.o11y.generic.text" }}
-    *Site:* {{ .GroupLabels.site }}
+    *Site:* {{ .CommonLabels.site }}
     *Alert:* {{ .GroupLabels.alertname }}
     *Summary:* {{ .CommonAnnotations.summary }}
     {{ template "__o11y_alert_list" . }}
@@ -16,8 +16,8 @@ data:
   slack-kube-alert.tmpl: |
     {{ define "slack.o11y.kube.text" }}
     *Alert:* {{ .GroupLabels.alertname }}
-    *Site:* {{ .GroupLabels.site }}
-    *Kube cluster:* {{ .GroupLabels.prom }}
+    *Site:* {{ .CommonLabels.site }}
+    *Kube cluster:* {{ .CommonLabels.prom }}
     *Namespace:* {{ .GroupLabels.namespace }}
     *Summary:* {{ .CommonAnnotations.summary }}
     {{ template "__o11y_alert_list" . }}

--- a/fleet/lib/kube-prometheus-stack-pre/configmap-alertmanager-templates.yaml
+++ b/fleet/lib/kube-prometheus-stack-pre/configmap-alertmanager-templates.yaml
@@ -4,9 +4,42 @@ metadata:
   name: alertmanager-templates
 data:
   slack-generic-alert.tmpl: |
-    {{ define "slack.o11y.genericAlert" }}
+    {{ define "slack.o11y.generic.text" }}
+    *Site:* {{ .GroupLabels.site }}
+    *Prometheus:* {{ .GroupLabels.prometheus }}
     *Alert:* {{ .GroupLabels.alertname }}
     *Summary:* {{ .CommonAnnotations.summary }}
+    {{ template "__o11y_alert_list" . }}
+    {{ end }}
+    {{ define "slack.o11y.generic.title"}}
+    [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.prometheus }}/{{ .GroupLabels.alertname }}
+    {{ end }}
+  slack-kube-alert.tmpl: |
+    {{ define "slack.o11y.kube.text" }}
+    *Alert:* {{ .GroupLabels.alertname }}
+    *Site:* {{ .GroupLabels.site }}
+    *Kube cluster:* {{ .GroupLabels.k8s-cluster }}
+    *Namespace:* {{ .GroupLabels.namespace }}
+    *Summary:* {{ .CommonAnnotations.summary }}
+    {{ template "__o11y_alert_list" . }}
+    {{ end }}
+    {{ define "slack.o11y.kube.title"}}
+    [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.prometheus }}/{{ .GroupLabels.namespace }}/{{ .GroupLabels.alertname }}
+    {{ end }}
+  slack-network-alert.tmpl: |
+    {{ define "slack.o11y.network.text" }}
+    *Device:* {{ .GroupLabels.instance }}
+    {{ template "__o11y_alert_list" . }}
+    {{ end }}
+  slack-node-alert.tmpl: |
+    {{ define "slack.o11y.node.text" }}
+    *Instance:* {{ .GroupLabels.instance }}
+    {{ template "__o11y_alert_list" . }}
+    {{ end }}
+  template-helpers.tmpl: |
+    {{ define "__o11y_alert_list" }}
+    *Alerts:*
+    =========
     {{ range .Alerts -}}
     - *Alert:* {{ .Labels.alertname }}
       *Summary:* {{ .Annotations.summary }}
@@ -14,49 +47,8 @@ data:
       *Severity:* {{ .Labels.severity }}
       *Time:* {{ .StartsAt.Format "2006-01-02 15:04:05 MST" }}
       *Labels:*
-      {{ range .Labels.SortedPairs }} - *{{ .Name }}:* `{{ .Value }}`
+      {{ range .Labels.SortedPairs -}}
+      - *{{ .Name }}:* `{{ .Value }}`
       {{ end }}
-    {{ end }}
-    {{ end }}
-  slack-kube-alert.tmpl: |
-    {{ define "slack.o11y.kubeAlert" }}
-    *Alert:* {{ .GroupLabels.alertname }}
-    *Namespace:* {{ .GroupLabels.namespace }}
-    *Summary:* {{ .CommonAnnotations.summary }}
-    {{ range .Alerts }}
-    - *Runbook:* {{ .Annotations.runbook_url }}
-      *Description:* {{ .Annotations.description }}
-      *Severity:* {{ .Labels.severity }}
-      *Time:* {{ .StartsAt.Format "2006-01-02 15:04:05 MST" }}
-      *Labels:*
-      {{ range .Labels.SortedPairs }} - *{{ .Name }}:* `{{ .Value }}`
-      {{ end }}
-    {{ end }}
-    {{ end }}
-  slack-network-alert.tmpl: |
-    {{ define "slack.o11y.networkAlert" }}
-    *Device:* {{ .GroupLabels.instance }}
-    *Alerts:*
-    {{ range .Alerts }}
-    - *Alert:* {{ .Labels.alertname }}
-      *Summary:* {{ .Annotations.summary }}
-      *Description:* {{ .Annotations.description }}
-      *Severity:* {{ .Labels.severity }}
-      *Time:* {{ .StartsAt.Format "2006-01-02 15:04:05 MST" }}
-      *Labels:*
-      {{ range .Labels.SortedPairs }} - *{{ .Name }}:* `{{ .Value }}`
-      {{ end }}
-    {{ end }}
-    {{ end }}
-  slack-node-alert.tmpl: |
-    {{ define "slack.o11y.nodeAlert" }}
-    *Instance:* {{ .GroupLabels.instance }}
-    *Alerts:*
-    {{ range .Alerts }}
-    - *Alert:* {{ .Labels.alertname }}
-      *Summary:* {{ .Annotations.summary }}
-      *Description:* {{ .Annotations.description }}
-      *Severity:* {{ .Labels.severity }}
-      *Time:* {{ .StartsAt.Format "2006-01-02 15:04:05 MST" }}
-    {{ end }}
+    {{- end }}
     {{ end }}

--- a/fleet/lib/kube-prometheus-stack-pre/configmap-alertmanager-templates.yaml
+++ b/fleet/lib/kube-prometheus-stack-pre/configmap-alertmanager-templates.yaml
@@ -12,19 +12,19 @@ data:
     {{ template "__o11y_alert_list" . }}
     {{ end }}
     {{ define "slack.o11y.generic.title"}}
-    [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.prometheus }}/{{ .GroupLabels.alertname }}
+    [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.prom }}/{{ .GroupLabels.alertname }}
     {{ end }}
   slack-kube-alert.tmpl: |
     {{ define "slack.o11y.kube.text" }}
     *Alert:* {{ .GroupLabels.alertname }}
     *Site:* {{ .GroupLabels.site }}
-    *Kube cluster:* {{ .GroupLabels.kubecluster }}
+    *Kube cluster:* {{ .GroupLabels.prom }}
     *Namespace:* {{ .GroupLabels.namespace }}
     *Summary:* {{ .CommonAnnotations.summary }}
     {{ template "__o11y_alert_list" . }}
     {{ end }}
     {{ define "slack.o11y.kube.title"}}
-    [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.prometheus }}/{{ .GroupLabels.namespace }}/{{ .GroupLabels.alertname }}
+    [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.prom }}/{{ .GroupLabels.namespace }}/{{ .GroupLabels.alertname }}
     {{ end }}
   slack-network-alert.tmpl: |
     {{ define "slack.o11y.network.text" }}

--- a/fleet/lib/kube-prometheus-stack-pre/configmap-alertmanager-templates.yaml
+++ b/fleet/lib/kube-prometheus-stack-pre/configmap-alertmanager-templates.yaml
@@ -6,7 +6,6 @@ data:
   slack-generic-alert.tmpl: |
     {{ define "slack.o11y.generic.text" }}
     *Site:* {{ .GroupLabels.site }}
-    *Prometheus:* {{ .GroupLabels.prometheus }}
     *Alert:* {{ .GroupLabels.alertname }}
     *Summary:* {{ .CommonAnnotations.summary }}
     {{ template "__o11y_alert_list" . }}

--- a/fleet/lib/kube-prometheus-stack-pre/externalsecret-grafana-keycloack.yaml
+++ b/fleet/lib/kube-prometheus-stack-pre/externalsecret-grafana-keycloack.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-keycloack-credentials
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  data:
+  - remoteRef:
+      key: grafana-keycloack-credentials
+      property: username
+    secretKey: client_id
+  - remoteRef:
+      key: grafana-keycloack-credentials
+      property: credential
+    secretKey: client_secret
+  - remoteRef:
+      key: grafana-keycloack-credentials
+      property: hostname
+    secretKey: keycloack_url
+  refreshInterval: 1h
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain

--- a/fleet/lib/kube-prometheus-stack-pre/externalsecret-lsst-webhooks.yaml
+++ b/fleet/lib/kube-prometheus-stack-pre/externalsecret-lsst-webhooks.yaml
@@ -2,22 +2,17 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: o11y-webhooks
+  name: lsst-webhooks
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword
   data:
-    - secretKey: slackWebhookKey
+    - secretKey: slack-test
       remoteRef:
         key: "slack #rubinobs-monitoring-test webhook url"
         property: credential
-    - secretKey: squadcastWebhookKey
+    - secretKey: squadcast-example
       remoteRef:
         key: squadcast prometheus service
         property: credential
-  target:
-    template:
-      data:
-        o11y-slack: "{{.slackWebhookKey}}"
-        o11y-squadcast: "{{.squadcastWebhookKey}}"

--- a/fleet/lib/kube-prometheus-stack-pre/fleet.yaml
+++ b/fleet/lib/kube-prometheus-stack-pre/fleet.yaml
@@ -3,7 +3,7 @@ defaultNamespace: kube-prometheus-stack
 labels:
   bundle: &name kube-prometheus-stack-pre
 namespaceLabels:
-  o11y.eu/monitor: enabled
+  lsst.io/discover: "true"
 helm:
   releaseName: *name
   timeoutSeconds: 300

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -44,9 +44,7 @@ prometheus:
     remoteWrite:
       - url: http://mimir-distributed-gateway.mimir:80/api/v1/push
     externalLabels:
-      kubecluster: "${ .ClusterName }"
-      site: "${ .ClusterLabels.site }"
-    prometheusExternalLabelName: "${ .ClusterLabels.site }-${ .ClusterName }"
+      prom: "${ .ClusterLabels.site }/${ .ClusterName }"
     serviceMonitorSelectorNilUsesHelmValues: false
     podMonitorSelectorNilUsesHelmValues: false
     serviceMonitorNamespaceSelector:

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -44,6 +44,7 @@ prometheus:
     remoteWrite:
       - url: http://mimir-distributed-gateway.mimir:80/api/v1/push
     externalLabels:
+      site: "${ .ClusterLabels.site }"
       prom: "${ .ClusterLabels.site }/${ .ClusterName }"
     serviceMonitorSelectorNilUsesHelmValues: false
     podMonitorSelectorNilUsesHelmValues: false

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -285,6 +285,11 @@ grafana:
       enabled: true
     dashboards:
       enabled: true
+  extraSecretMounts:
+    - name: keycloack-credentials
+      mountPath: /etc/secrets/keycloack-credentials
+      secretName: grafana-keycloack-credentials
+      readOnly: true
   datasources:
     datasource.yaml:
       apiVersion: 1

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -46,7 +46,7 @@ prometheus:
     externalLabels:
       k8s-cluster: "${ .ClusterName }"
       site: "${ .ClusterLabels.site }"
-    prometheusExternalLabelName: "\"${ .ClusterLabels.site }/${ .ClusterName }\""
+    prometheusExternalLabelName: "${ .ClusterLabels.site }-${ .ClusterName }"
     serviceMonitorSelectorNilUsesHelmValues: false
     podMonitorSelectorNilUsesHelmValues: false
     serviceMonitorNamespaceSelector:

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -171,25 +171,27 @@ alertmanager:
           - username: "${ .ClusterName }-general"
             channel: "#rubinobs-monitoring-test"
             send_resolved: true
-            text: '{{ template "slack.o11y.genericAlert" . }}'
+            title: '{{ template "slack.o11y.generic.title" . }}'
+            text: '{{ template "slack.o11y.generic.text" . }}'
       - name: "slack-kube-test"
         slack_configs:
           - username: "${ .ClusterName }-kube"
             channel: "#rubinobs-monitoring-test"
             send_resolved: true
-            text: '{{ template "slack.o11y.kubeAlert" . }}'
+            title: '{{ template "slack.o11y.kube.title" . }}'
+            text: '{{ template "slack.o11y.kube.text" . }}'
       - name: "slack-node-test"
         slack_configs:
           - username: "${ .ClusterName }-nodes"
             channel: "#rubinobs-monitoring-test"
             send_resolved: true
-            text: '{{ template "slack.o11y.nodeAlert" . }}'
+            text: '{{ template "slack.o11y.node.text" . }}'
       - name: "slack-network-test"
         slack_configs:
           - username: "${ .ClusterName }-network"
             channel: "#rubinobs-monitoring-test"
             send_resolved: true
-            text: '{{ template "slack.o11y.networkAlert" . }}'
+            text: '{{ template "slack.o11y.network.text" . }}'
       - name: "squadcast-test"
         webhook_configs:
           - url_file: /etc/alertmanager/secrets/lsst-webhooks/squadcast-example

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -2,7 +2,18 @@
 crds:
   enabled: false
 
+defaultRules:
+  create: true
+  labels:
+    lsst.io/rule: "true"
+  additionalRuleLabels:
+    receivers: ",squadcast,"
+
 prometheusOperator:
+  enabled: true
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
   resources:
     limits:
       cpu: 1
@@ -30,18 +41,40 @@ prometheus:
         cpu: 1
         memory: 12Gi
     externalUrl: "https://prometheus.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org"
-    serviceMonitorNamespaceSelector:
-      matchLabels:
-        o11y.eu/monitor: enabled
-    serviceMonitorSelectorNilUsesHelmValues: false
-    serviceMonitorSelector: {}
-    podMonitorNamespaceSelector:
-      matchLabels:
-        o11y.eu/monitor: enabled
-    podMonitorSelectorNilUsesHelmValues: false
-    podMonitorSelector: {}
     remoteWrite:
       - url: http://mimir-distributed-gateway.mimir:80/api/v1/push
+    serviceMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorNamespaceSelector:
+      matchLabels:
+        lsst.io/discover: "true"
+    serviceMonitorSelector:
+      matchLabels:
+        lsst.io/monitor: "true"
+    podMonitorNamespaceSelector:
+      matchLabels:
+        lsst.io/discover: "true"
+    podMonitorSelector:
+      matchLabels:
+        lsst.io/monitor: "true"
+    ruleNamespaceSelector:
+      matchLabels:
+        lsst.io/discover: "true"
+    ruleSelector:
+      matchLabels:
+        lsst.io/rule: "true"
+    scrapeConfigNamespaceSelector:
+      matchLabels:
+        lsst.io/discover: "true"
+    scrapeConfigSelector:
+      matchLabels:
+        lsst.io/scrape: "true"
+    probeNamespaceSelector:
+      matchLabels:
+        lsst.io/discover: "true"
+    probeSelector:
+      matchLabels:
+        lsst.io/probe: "true"
   ingress:
     enabled: true
     annotations:
@@ -61,6 +94,9 @@ prometheus:
           - "prometheus.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org"
 
 alertmanager:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
   alertmanagerSpec:
     resources:
       limits:
@@ -71,7 +107,9 @@ alertmanager:
         memory: 512Mi
     externalUrl: "https://alertmanager.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org"
     secrets:
-      - o11y-webhooks
+      - lsst-webhooks
+    configMaps:
+      - alertmanager-templates
   ingress:
     enabled: true
     annotations:
@@ -92,55 +130,88 @@ alertmanager:
   config:
     global:
       resolve_timeout: 5m
-      slack_api_url_file: /etc/alertmanager/secrets/o11y-webhooks/o11y-slack
+      slack_api_url_file: /etc/alertmanager/secrets/lsst-webhooks/slack-test
     route:
-      group_by: [namespace, cluster]
+      group_by: ["alertname", "namespace"]
       group_wait: 30s
       group_interval: 5m
       repeat_interval: 24h
-      receiver: slack-test
+      receiver: "slack-test"
       routes:
         - receiver: "null"
           matchers:
             - alertname = "InfoInhibitor"
-        - receiver: watchdog
+        - receiver: "watchdog"
           matchers:
             - alertname = "Watchdog"
-        - receiver: squadcast-test
+        - receiver: "squadcast-test"
           matchers:
-            - receiver =~ ".*,squadcast,.*"
+            - receivers =~ ".*,squadcast,.*"
           continue: true
+        - receiver: slack-kube-test
+          matchers:
+            - alertname =~ "Kube.*"
+        - receiver: slack-node-test
+          group_by: ["instance"]
+          matchers:
+            - alertname =~ "Node.*"
+        - receiver: slack-network-test
+          group_by: ["instance"]
+          matchers:
+            - alertname =~ "Network.*"
     receivers:
       - name: "null"
-      - name: watchdog
-      - name: slack-test
+      - name: "watchdog"
+      - name: "slack-test"
         slack_configs:
-          - username: "${ .ClusterName }-prometheus"
+          - username: "${ .ClusterName }-general"
             channel: "#rubinobs-monitoring-test"
             send_resolved: true
-      - name: squadcast-test
+            text: '{{ template "slack.o11y.genericAlert" . }}'
+      - name: "slack-kube-test"
+        slack_configs:
+          - username: "${ .ClusterName }-kube"
+            channel: "#rubinobs-monitoring-test"
+            send_resolved: true
+            text: '{{ template "slack.o11y.kubeAlert" . }}'
+      - name: "slack-node-test"
+        slack_configs:
+          - username: "${ .ClusterName }-nodes"
+            channel: "#rubinobs-monitoring-test"
+            send_resolved: true
+            text: '{{ template "slack.o11y.nodeAlert" . }}'
+      - name: "slack-network-test"
+        slack_configs:
+          - username: "${ .ClusterName }-network"
+            channel: "#rubinobs-monitoring-test"
+            send_resolved: true
+            text: '{{ template "slack.o11y.networkAlert" . }}'
+      - name: "squadcast-test"
         webhook_configs:
-          - url_file: /etc/alertmanger/secrets/o11y-webhooks/o11y-squadcast
+          - url_file: /etc/alertmanager/secrets/lsst-webhooks/squadcast-example
     inhibit_rules:
       - source_matchers:
           - alertname = "InfoInhibitor"
         target_matchers:
           - severity = "info"
-        equal: [namespace]
+        equal: ["namespace"]
       - source_matchers:
           - severity = "critical"
         target_matchers:
           - severity =~ "info|warning"
-        equal: [alertname]
+        equal: ["alertname"]
       - source_matchers:
           - severity = "warning"
         target_matchers:
           - severity = "info"
-        equal: [alertname]
+        equal: ["alertname"]
     templates:
-      - /etc/alertmanager/config/*.tmpl
+      - "/etc/alertmanager/configmaps/alertmanager-templates/*.tmpl"
 
 grafana:
+  serviceMonitor:
+    labels:
+      lsst.io/monitor: "true"
   resources:
     limits:
       cpu: 4
@@ -227,6 +298,23 @@ kubeProxy:
 kubeControllerManager:
   enabled: false
 
+# specify the needed label for the serviceMonitor
+kubelet:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
+coreDns:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
+kubeDns:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
+kubeEtcd:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
 prometheus-node-exporter:
   resources:
     limits:
@@ -235,7 +323,10 @@ prometheus-node-exporter:
     requests:
       cpu: 100m
       memory: 64Mi
-
+  prometheus:
+    monitor:
+      additionalLabels:
+        lsst.io/monitor: "true"
 kube-state-metrics:
   resources:
     limits:
@@ -244,3 +335,9 @@ kube-state-metrics:
     requests:
       cpu: 10m
       memory: 256Mi
+  prometheus:
+    monitor:
+      additionalLabels:
+        lsst.io/monitor: "true"
+  selfMonitor:
+    enabled: true

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -46,7 +46,7 @@ prometheus:
     externalLabels:
       k8s-cluster: "${ .ClusterName }"
       site: "${ .ClusterLabels.site }"
-    prometheusExternalLabelName: "${ .ClusterLabels.site }/${ .ClusterName }"
+    prometheusExternalLabelName: "\"${ .ClusterLabels.site }/${ .ClusterName }\""
     serviceMonitorSelectorNilUsesHelmValues: false
     podMonitorSelectorNilUsesHelmValues: false
     serviceMonitorNamespaceSelector:

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -44,7 +44,7 @@ prometheus:
     remoteWrite:
       - url: http://mimir-distributed-gateway.mimir:80/api/v1/push
     externalLabels:
-      k8s-cluster: "${ .ClusterName }"
+      kubecluster: "${ .ClusterName }"
       site: "${ .ClusterLabels.site }"
     prometheusExternalLabelName: "${ .ClusterLabels.site }-${ .ClusterName }"
     serviceMonitorSelectorNilUsesHelmValues: false
@@ -230,10 +230,31 @@ grafana:
   deploymentStrategy:
     type: Recreate  # default is RollingUpdate, which doesn't work w/ persistence enabled
   grafana.ini:
+    server:
+      domain: "grafana.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org"
+      root_url: "https://grafana.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org"
+    feature_toggles:
+      enable: "autoMigrateOldPanels"
     auth.ldap:
       enabled: true
       allow_sign_up: true
       config_file: /etc/grafana/ldap.toml
+    auth.generic_oauth:
+      allow_assign_grafana_admin: true
+      allow_sign_up: true
+      api_url: https://keycloak.ls.lsst.org/realms/master/protocol/openid-connect/userinfo
+      auth_url: https://keycloak.ls.lsst.org/realms/master/protocol/openid-connect/auth
+      client_id: $__file{/etc/secrets/keycloack-credentials/client_id}
+      client_secret: $__file{/etc/secrets/keycloack-credentials/client_secret}
+      email_attribute_path: email
+      enabled: true
+      group_attribute_path: groups
+      login_attribute_path: preferred_username
+      name: keycloack.ls.lsst.org
+      role_attribute_path: contains(groups[*], 'grafana-admin') && 'GrafanaAdmin' || contains(groups[*], 'grafana-admin') && 'Admin' || contains(groups[*], 'grafana-editor') && 'Editor' || 'Viewer'
+      scopes: openid profile email groups roles offline_access
+      token_url: https://keycloak.ls.lsst.org/realms/master/protocol/openid-connect/token
+      use_refresh_token: true
   ldap:
     enabled: true
     existingSecret: grafana-ldap

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -43,6 +43,10 @@ prometheus:
     externalUrl: "https://prometheus.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org"
     remoteWrite:
       - url: http://mimir-distributed-gateway.mimir:80/api/v1/push
+    externalLabels:
+      k8s-cluster: "${ .ClusterName }"
+      site: "${ .ClusterLabels.site }"
+    prometheusExternalLabelName: "${ .ClusterLabels.site }/${ .ClusterName }"
     serviceMonitorSelectorNilUsesHelmValues: false
     podMonitorSelectorNilUsesHelmValues: false
     serviceMonitorNamespaceSelector:

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -135,7 +135,7 @@ alertmanager:
       resolve_timeout: 5m
       slack_api_url_file: /etc/alertmanager/secrets/lsst-webhooks/slack-test
     route:
-      group_by: ["alertname", "namespace"]
+      group_by: ["alertname", "namespace", "site"]
       group_wait: 30s
       group_interval: 5m
       repeat_interval: 24h

--- a/fleet/lib/kube-prometheus-stack/fleet.yaml
+++ b/fleet/lib/kube-prometheus-stack/fleet.yaml
@@ -3,7 +3,7 @@ defaultNamespace: &name kube-prometheus-stack
 labels:
   bundle: *name
 namespaceLabels:
-  o11y.eu/monitor: enabled
+  lsst.io/discover: "true"
 helm:
   chart: *name
   releaseName: *name

--- a/fleet/lib/kube-prometheus-stack/fleet.yaml
+++ b/fleet/lib/kube-prometheus-stack/fleet.yaml
@@ -54,6 +54,12 @@ targetCustomizations:
       valuesFiles:
         - aggregator/values.yaml
         - overlays/ruka/values.yaml
+  - name: ayekan
+    clusterName: ayekan
+    helm:
+      valuesFiles:
+        - aggregator/values.yaml
+        - overlays/ayekan/values.yaml
   - name: default
     clusterSelector:
       matchLabels:

--- a/fleet/lib/kube-prometheus-stack/overlays/ayekan/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/overlays/ayekan/values.yaml
@@ -1,6 +1,9 @@
 ---
 prometheus:
   prometheusSpec:
+    configMaps:
+      - prometheus-snmp-csv-network
+      - pdu-targets
     additionalScrapeConfigs:
       - job_name: node-exporter-dev
         puppetdb_sd_configs:

--- a/fleet/lib/kube-prometheus-stack/overlays/ayekan/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/overlays/ayekan/values.yaml
@@ -1,0 +1,139 @@
+---
+prometheus:
+  prometheusSpec:
+    additionalScrapeConfigs:
+      - job_name: node-exporter-dev
+        puppetdb_sd_configs:
+          - url: "http://puppetdb.dev.lsst.org:8080"
+            query: "resources { type = \"Class\" and title = \"Prometheus::Node_exporter\" }"
+            refresh_interval: "30s"
+            follow_redirects: true
+            include_parameters: true
+            enable_http2: true
+            port: 9100
+        relabel_configs: &puppet-node-exporter
+          - source_labels: [__meta_puppetdb_certname]
+            target_label: instance
+          - source_labels: [__meta_puppetdb_environment]
+            target_label: environment
+      - job_name: node-exporter-ls
+        puppetdb_sd_configs:
+          - url: "http://puppetdb.ls.lsst.org:8080"
+            query: "resources { type = \"Class\" and title = \"Prometheus::Node_exporter\" }"
+            refresh_interval: "30s"
+            follow_redirects: true
+            include_parameters: true
+            enable_http2: true
+            port: 9100
+        relabel_configs: *puppet-node-exporter
+      - job_name: blackbox-ping-dev
+        metrics_path: /probe
+        params:
+          module: [icmp]
+        puppetdb_sd_configs:
+          - url: "http://puppetdb.dev.lsst.org:8080"
+            query: "resources { type = \"Class\" and title = \"Prometheus::Node_exporter\" }"
+            refresh_interval: "30s"
+            follow_redirects: true
+            include_parameters: true
+            enable_http2: true
+        relabel_configs: &k8s-blackbox-monitoring
+          - source_labels: [__meta_puppetdb_certname]
+            target_label: __param_target
+          - source_labels: [__param_target]
+            target_label: instance
+          - target_label: __address__
+            replacement: "prometheus-blackbox-exporter.blackbox-exporter:9115"
+      - job_name: blackbox-ping-ls
+        metrics_path: /probe
+        params:
+          module: [icmp]
+        puppetdb_sd_configs:
+          - url: "http://puppetdb.ls.lsst.org:8080"
+            query: "resources { type = \"Class\" and title = \"Prometheus::Node_exporter\" }"
+            refresh_interval: "30s"
+            follow_redirects: true
+            include_parameters: true
+            enable_http2: true
+        relabel_configs: *k8s-blackbox-monitoring
+      - job_name: snmp-csv-network
+        metrics_path: /snmp
+        params:
+          module: [if_mib]
+          auth: [rubin_v2]
+        file_sd_configs:
+          - files:
+              - "/etc/prometheus/configmaps/prometheus-snmp-csv-network/snmp-csv-network.json"
+        relabel_configs: &network-snmp-relabel
+          - source_labels: [__address__]
+            target_label: __param_target
+          - source_labels: [__meta_hostname]
+            target_label: instance
+          - source_labels: [__meta_network_function]
+            target_label: network_function
+          - target_label: __address__
+            replacement: "prometheus-snmp-exporter.snmp-exporter:9116"
+      - job_name: blackbox-csv-network
+        metrics_path: /probe
+        params:
+          module: [icmp]
+        file_sd_configs:
+          - files:
+              - "/etc/prometheus/configmaps/prometheus-snmp-csv-network/snmp-csv-network.json"
+        relabel_configs:
+          - source_labels: [__address__]
+            target_label: __param_target
+          - source_labels: [__meta_hostname]
+            target_label: instance
+          - source_labels: [__meta_network_function]
+            target_label: network_function
+          - target_label: __address__
+            replacement: "prometheus-blackbox-exporter.blackbox-exporter:9115"
+      - job_name: snmp-raritan-pdu
+        metrics_path: /snmp
+        params:
+          module: [raritan]
+          auth: [rubin_v2]
+        file_sd_configs:
+          - files:
+              - "/etc/prometheus/configmaps/pdu-targets/pdu-targets.json"
+        relabel_configs: &snmp-relabel
+          - source_labels: [__address__]
+            target_label: __param_target
+          - source_labels: [__meta_hostname]
+            target_label: instance
+          - target_label: __address__
+            replacement: "prometheus-snmp-exporter.snmp-exporter:9116"
+      - job_name: snmp-xups-public
+        metrics_path: /snmp
+        params:
+          module: [xups]
+          auth: [public_v1]
+        static_configs:
+          - targets:
+              - 10.18.3.31
+            labels:
+              __meta_hostname: ups-01
+        relabel_configs: *snmp-relabel
+      - job_name: snmp-xups
+        metrics_path: /snmp
+        params:
+          module: [xups]
+          auth: [lsst_v1]
+        static_configs:
+          - targets:
+              - 10.18.3.62
+            labels:
+              __meta_hostname: ups-02
+        relabel_configs: *snmp-relabel
+      - job_name: snmp-schneider-pm5xxx
+        metrics_path: /snmp
+        params:
+          module: [schneider_pm5xxx]
+          auth: [public_v1]
+        static_configs:
+          - targets:
+              - 10.18.3.21
+            labels:
+              __meta_hostname: pdu-01
+        relabel_configs: *snmp-relabel

--- a/fleet/lib/kyverno/fleet.yaml
+++ b/fleet/lib/kyverno/fleet.yaml
@@ -4,7 +4,7 @@ defaultNamespace: &name kyverno
 labels:
   bundle: *name
 namespaceLabels:
-  o11y.eu/monitor: enabled
+  lsst.io/discover: "true"
 helm:
   chart: *name
   releaseName: *name
@@ -24,12 +24,24 @@ helm:
         cpu: 100m
         memory: 1Gi
     admissionController:
+      serviceMonitor:
+        enabled: true
+        additionalLabels:
+          lsst.io/monitor: "true"
       metricsService:
         create: true
     backgroundController:
+      serviceMonitor:
+        enabled: true
+        additionalLabels:
+          lsst.io/monitor: "true"
       metricsService:
         create: true
     cleanupController:
+      serviceMonitor:
+        enabled: true
+        additionalLabels:
+          lsst.io/monitor: "true"
       metricsService:
         create: true
     reportsController:
@@ -41,6 +53,10 @@ helm:
         requests:
           cpu: 100m
           memory: 64Mi
+      serviceMonitor:
+        enabled: true
+        additionalLabels:
+          lsst.io/monitor: "true"
       metricsService:
         create: true
 dependsOn:

--- a/fleet/lib/metallb/fleet.yaml
+++ b/fleet/lib/metallb/fleet.yaml
@@ -19,6 +19,8 @@ helm:
     speaker:
       priorityClassName: system-node-critical
     prometheus:
+      namespace: "kube-prometheus-stack"
+      serviceAccount: "kube-prometheus-stack-prometheus"
       prometheusRule:
         enabled: true
         additionalLabels:

--- a/fleet/lib/metallb/fleet.yaml
+++ b/fleet/lib/metallb/fleet.yaml
@@ -1,5 +1,7 @@
 ---
 defaultNamespace: metallb-system
+namespaceLabels:
+  lsst.io/discover: "true"
 labels:
   bundle: &name metallb
 helm:
@@ -16,6 +18,19 @@ helm:
       priorityClassName: system-cluster-critical
     speaker:
       priorityClassName: system-node-critical
+    prometheus:
+      prometheusRule:
+        enabled: true
+        additionalLabels:
+          lsst.io/rule: "true"
+      serviceMonitor:
+        enabled: true
+        controller:
+          additionalLabels:
+            lsst.io/monitor: "true"
+        speaker:
+          additionalLabels:
+            lsst.io/monitor: "true"
 diff:
   comparePatches:
     - apiVersion: apiextensions.k8s.io/v1

--- a/fleet/lib/mimir-pre/fleet.yaml
+++ b/fleet/lib/mimir-pre/fleet.yaml
@@ -3,11 +3,7 @@ defaultNamespace: mimir
 labels:
   bundle: &name mimir-pre
 namespaceLabels:
-  o11y.eu/monitor: enabled
-  # https://github.com/rancher/fleet/issues/2262
-  lsst.io/author: fbegyn
   lsst.io/discover: "true"
-  lsst.io/monitor: "true"
 helm:
   releaseName: *name
   takeOwnership: true

--- a/fleet/lib/mimir/fleet.yaml
+++ b/fleet/lib/mimir/fleet.yaml
@@ -4,11 +4,7 @@ defaultNamespace: &name mimir
 labels:
   bundle: *name
 namespaceLabels:
-  o11y.eu/monitor: enabled
-  # https://github.com/rancher/fleet/issues/2262
-  lsst.io/author: fbegyn
   lsst.io/discover: "true"
-  lsst.io/monitor: "true"
 helm:
   chart: &chart mimir-distributed
   releaseName: *chart

--- a/fleet/lib/mimir/overlays/ayekan/values.yaml
+++ b/fleet/lib/mimir/overlays/ayekan/values.yaml
@@ -2,20 +2,15 @@
 metaMonitoring:
   dashboards:
     labels:
-      lsst.io/author: fbegyn
-      lsst.io/discover: "true"
+      lsst.io/dashboard: "true"
       grafana_dashboard: "1"
   serviceMonitor:
     labels:
-      lsst.io/author: fbegyn
       lsst.io/monitor: "true"
-      lsst.io/discover: "true"
   prometheusRule:
     labels:
-      lsst.io/author: fbegyn
-      lsst.io/discover: "true"
+      lsst.io/rule: "true"
 gateway:
   ingress:
     labels:
-      lsst.io/author: fbegyn
-      lsst.io/discover: "true"
+      lsst.io/monitor: "true"

--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -9,16 +9,16 @@ metaMonitoring:
   dashboards:
     enabled: true
     labels:
-      o11y.eu/monitor: enabled
+      lsst.io/dashboard: "true"
       grafana_dashboard: "1"
   serviceMonitor:
     enabled: true
     labels:
-      o11y.eu/monitor: enabled
+      lsst.io/monitor: "true"
   prometheusRule:
     enabled: true
     labels:
-      o11y.eu/monitor: enabled
+      lsst.io/rule: "true"
 mimir:
   structuredConfig:
     common:

--- a/fleet/lib/rook-ceph-cluster/fleet.yaml
+++ b/fleet/lib/rook-ceph-cluster/fleet.yaml
@@ -1,5 +1,7 @@
 ---
 defaultNamespace: rook-ceph
+namespaceLabels:
+  lsst.io/discover: "true"
 labels:
   bundle: &name rook-ceph-cluster
 helm:

--- a/fleet/lib/rook-ceph-cluster/overlays/ayekan/values.yaml
+++ b/fleet/lib/rook-ceph-cluster/overlays/ayekan/values.yaml
@@ -24,9 +24,9 @@ toolbox:
 
 monitoring:
   enabled: true
+  createPrometheusRules: true
   rulesNamespaceOverride: rook-ceph
   prometheusRule:
-    enabled: true
     labels:
       lsst.io/rule: "true"
 

--- a/fleet/lib/rook-ceph-cluster/overlays/ayekan/values.yaml
+++ b/fleet/lib/rook-ceph-cluster/overlays/ayekan/values.yaml
@@ -25,6 +25,10 @@ toolbox:
 monitoring:
   enabled: true
   rulesNamespaceOverride: rook-ceph
+  prometheusRule:
+    enabled: true
+    labels:
+      lsst.io/rule: "true"
 
 cephClusterSpec:
   cephVersion:
@@ -59,6 +63,9 @@ cephClusterSpec:
       dataSource: zero
       iteration: 1
     allowUninstallWithVolumes: false
+  labels:
+    exporter:
+      lsst.io/monitor: "true"
   placement:
     all:
       nodeAffinity:

--- a/fleet/lib/rook-ceph/fleet.yaml
+++ b/fleet/lib/rook-ceph/fleet.yaml
@@ -3,7 +3,7 @@ defaultNamespace: &name rook-ceph
 labels:
   bundle: *name
 namespaceLabels:
-  o11y.eu/monitor: enabled
+  lsst.io/discover: "true"
 helm:
   chart: *name
   releaseName: *name

--- a/fleet/lib/rook-ceph/values.yaml
+++ b/fleet/lib/rook-ceph/values.yaml
@@ -19,6 +19,10 @@ discover:
     - <<: *storage_node_tol
   nodeAffinity: *storage_node_aff
 csi:
+  serviceMonitor:
+    enabled: true
+    labels:
+      lsst.io/monitor: "true"
   cephcsi:
     image: quay.io/cephcsi/cephcsi:v3.8.0
   provisionerTolerations:

--- a/fleet/lib/snmp-exporter-pre/fleet.yaml
+++ b/fleet/lib/snmp-exporter-pre/fleet.yaml
@@ -1,5 +1,7 @@
 ---
 defaultNamespace: snmp-exporter
+namespaceLabels:
+  lsst.io/discover: "true"
 labels:
   bundle: snmp-exporter-pre
 helm:

--- a/fleet/lib/snmp-exporter/fleet.yaml
+++ b/fleet/lib/snmp-exporter/fleet.yaml
@@ -1,5 +1,7 @@
 ---
 defaultNamespace: &name snmp-exporter
+namespaceLabels:
+  lsst.io/discover: "true"
 labels:
   bundle: *name
 helm:

--- a/fleet/lib/snmp-exporter/values.yaml
+++ b/fleet/lib/snmp-exporter/values.yaml
@@ -12,6 +12,8 @@ resources:
 
 serviceMonitor:
   enabled: true
+  selector:
+    lsst.io/monitor: "true"
 
 extraSecretMounts:
   - name: snmp-config

--- a/fleet/lib/strimzi-kafka-dashboards/fleet.yaml
+++ b/fleet/lib/strimzi-kafka-dashboards/fleet.yaml
@@ -3,7 +3,7 @@ defaultNamespace: &name strimzi-kafka-dashboards
 labels:
   bundle: *name
 namespaceLabels:
-  o11y.eu/monitor: enabled
+  lsst.io/discover: "true"
 helm:
   releaseName: *name
   takeOwnership: true

--- a/fleet/s/dev/c/ayekan/blackbox-exporter
+++ b/fleet/s/dev/c/ayekan/blackbox-exporter
@@ -1,1 +1,1 @@
-../../../../lib/blackbox-exporter/
+../../../../lib/blackbox-exporter

--- a/fleet/s/dev/c/ayekan/blackbox-exporter
+++ b/fleet/s/dev/c/ayekan/blackbox-exporter
@@ -1,0 +1,1 @@
+../../../../lib/blackbox-exporter/

--- a/fleet/s/dev/c/ayekan/kube-prometheus-stack
+++ b/fleet/s/dev/c/ayekan/kube-prometheus-stack
@@ -1,0 +1,1 @@
+../../../../lib/kube-prometheus-stack


### PR DESCRIPTION
Currently, only a single prometheus operator is allowed in a cluster (or very strict control over namespaces is needed). This branch makes an effort to split up the deployment of the prometheus operator and a prometheus stack for the o11y metrics project. It also rethinks the label used for monitoring discovery.