### PR TITLE
(konkong) add letsencrypt-dev clusterissuer

### DIFF
--- a/fleet/lib/cert-manager-conf/fleet.yaml
+++ b/fleet/lib/cert-manager-conf/fleet.yaml
@@ -17,6 +17,10 @@ dependsOn:
       matchLabels:
         bundle: external-secrets-conf
 targetCustomizations:
+  - name: konkong
+    clusterName: konkong
+    kustomize:
+      dir: overlays/konkong
   - name: dev
     clusterSelector:
       matchLabels:

--- a/fleet/lib/cert-manager-conf/overlays/konkong/clusterissuer-letsencrypt-dev.yaml
+++ b/fleet/lib/cert-manager-conf/overlays/konkong/clusterissuer-letsencrypt-dev.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-dev
+  namespace: cert-manager
+spec:
+  acme:
+    email: rubinobs-it-las@lsst.org
+    privateKeySecretRef:
+      name: letsencrypt
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+    - dns01:
+        route53:
+          accessKeyID: AKIAQSJOS2SFPN2PZ2VD
+          hostedZoneID: ZQGNOYQYRNW0C
+          region: us-east-1
+          secretAccessKeySecretRef:
+            key: aws_key
+            name: aws-route53
+      selector:
+        dnsZones:
+        - dev.lsst.org

--- a/fleet/lib/cert-manager-conf/overlays/konkong/clusterissuer-letsencrypt-staging.yaml
+++ b/fleet/lib/cert-manager-conf/overlays/konkong/clusterissuer-letsencrypt-staging.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+  namespace: cert-manager
+spec:
+  acme:
+    solvers:
+      - selector:
+          dnsZones:
+            - ls.lsst.org
+        dns01:
+          route53:
+            region: us-east-1
+            hostedZoneID: ZPIEHXTK3ZPMR
+            accessKeyIDSecretRef:
+              name: route53
+              key: AWS_ACCESS_KEY_ID
+            secretAccessKeySecretRef:
+              name: route53
+              key: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/cert-manager-conf/overlays/konkong/clusterissuer-letsencrypt.yaml
+++ b/fleet/lib/cert-manager-conf/overlays/konkong/clusterissuer-letsencrypt.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+  namespace: cert-manager
+spec:
+  acme:
+    solvers:
+      - selector:
+          dnsZones:
+            - ls.lsst.org
+        dns01:
+          route53:
+            region: us-east-1
+            hostedZoneID: ZPIEHXTK3ZPMR
+            accessKeyIDSecretRef:
+              name: route53
+              key: AWS_ACCESS_KEY_ID
+            secretAccessKeySecretRef:
+              name: route53
+              key: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/cert-manager-conf/overlays/konkong/externalsecret-route53.yaml
+++ b/fleet/lib/cert-manager-conf/overlays/konkong/externalsecret-route53.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: route53
+  namespace: cert-manager
+spec:
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: it-dns-ls (aws)
+        property: username
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: it-dns-ls (aws)
+        property: password

--- a/fleet/lib/cert-manager-conf/overlays/konkong/kustomization.yaml
+++ b/fleet/lib/cert-manager-conf/overlays/konkong/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+resources:
+  - ../../base
+  - clusterissuer-letsencrypt-dev.yaml
+patches:
+  - path: clusterissuer-letsencrypt-staging.yaml
+  - path: clusterissuer-letsencrypt.yaml
+  - path: externalsecret-route53.yaml

--- a/fleet/lib/rook-ceph-cluster/overlays/ayekan/values.yaml
+++ b/fleet/lib/rook-ceph-cluster/overlays/ayekan/values.yaml
@@ -185,7 +185,7 @@ ingress:
       nginx.ingress.kubernetes.io/server-snippet: |
         proxy_ssl_verify off;
     host:
-      name: &hostname ceph.ayekan.ls.lsst.org
+      name: &hostname ceph.ayekan.dev.lsst.org
     tls:
       - hosts:
           - *hostname


### PR DESCRIPTION
This clusterissuer is already in use on konkong but missing from the fleet configuration.