### PR TITLE
(fleet) use a github branch per site

### DIFF
--- a/fleet/lib/fleet-conf/overlays/cp/gitrepo-chonchon.yaml
+++ b/fleet/lib/fleet-conf/overlays/cp/gitrepo-chonchon.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: fleet-default
 spec:
   repo: https://github.com/lsst-it/k8s-cookbook
-  branch: master
+  branch: cp_production
   keepResources: true
   paths:
-    - fleet/site/cp/cluster/chonchon/*
+    - fleet/s/cp/c/chonchon/*
   targets:
     - name: chonchon
       clusterName: chonchon

--- a/fleet/lib/fleet-conf/overlays/cp/gitrepo-lukay.yaml
+++ b/fleet/lib/fleet-conf/overlays/cp/gitrepo-lukay.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: fleet-default
 spec:
   repo: https://github.com/lsst-it/k8s-cookbook
-  branch: master
+  branch: cp_production
   keepResources: true
   paths:
-    - fleet/site/cp/cluster/lukay/*
+    - fleet/s/cp/c/lukay/*
   targets:
     - name: lukay
       clusterName: lukay

--- a/fleet/lib/fleet-conf/overlays/dev/gitrepo-ayekan.yaml
+++ b/fleet/lib/fleet-conf/overlays/dev/gitrepo-ayekan.yaml
@@ -9,7 +9,7 @@ spec:
   branch: master
   keepResources: true
   paths:
-    - fleet/site/dev/cluster/ayekan/*
+    - fleet/s/dev/c/ayekan/*
   targets:
     - name: ayekan
       clusterName: ayekan

--- a/fleet/lib/fleet-conf/overlays/dev/gitrepo-kueyen.yaml
+++ b/fleet/lib/fleet-conf/overlays/dev/gitrepo-kueyen.yaml
@@ -9,7 +9,7 @@ spec:
   branch: master
   keepResources: true
   paths:
-    - fleet/site/dev/cluster/kueyen/*
+    - fleet/s/dev/c/kueyen/*
   targets:
     - name: kueyen
       clusterName: kueyen

--- a/fleet/lib/fleet-conf/overlays/dev/gitrepo-namkueyen.yaml
+++ b/fleet/lib/fleet-conf/overlays/dev/gitrepo-namkueyen.yaml
@@ -9,7 +9,7 @@ spec:
   branch: master
   keepResources: true
   paths:
-    - fleet/site/dev/cluster/namkueyen/*
+    - fleet/s/dev/c/namkueyen/*
   targets:
     - name: namkueyen
       clusterName: namkueyen

--- a/fleet/lib/fleet-conf/overlays/dev/gitrepo-ruka.yaml
+++ b/fleet/lib/fleet-conf/overlays/dev/gitrepo-ruka.yaml
@@ -9,7 +9,7 @@ spec:
   branch: master
   keepResources: true
   paths:
-    - fleet/site/dev/cluster/ruka/*
+    - fleet/s/dev/c/ruka/*
   targets:
     - name: ruka
       clusterName: ruka

--- a/fleet/lib/fleet-conf/overlays/ls/gitrepo-gaw.yaml
+++ b/fleet/lib/fleet-conf/overlays/ls/gitrepo-gaw.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: fleet-default
 spec:
   repo: https://github.com/lsst-it/k8s-cookbook
-  branch: master
+  branch: ls_production
   keepResources: true
   paths:
-    - fleet/site/ls/cluster/gaw/*
+    - fleet/s/ls/c/gaw/*
   targets:
     - name: gaw
       clusterName: gaw

--- a/fleet/lib/fleet-conf/overlays/ls/gitrepo-konkong.yaml
+++ b/fleet/lib/fleet-conf/overlays/ls/gitrepo-konkong.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: fleet-default
 spec:
   repo: https://github.com/lsst-it/k8s-cookbook
-  branch: master
+  branch: ls_production
   keepResources: true
   paths:
-    - fleet/site/ls/cluster/konkong/*
+    - fleet/s/ls/c/konkong/*
   targets:
     - name: konkong
       clusterName: konkong

--- a/fleet/lib/fleet-conf/overlays/ls/gitrepo-luan.yaml
+++ b/fleet/lib/fleet-conf/overlays/ls/gitrepo-luan.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: fleet-default
 spec:
   repo: https://github.com/lsst-it/k8s-cookbook
-  branch: master
+  branch: ls_production
   keepResources: true
   paths:
-    - fleet/site/ls/cluster/luan/*
+    - fleet/s/ls/c/luan/*
   targets:
     - name: luan
       clusterName: luan

--- a/fleet/lib/fleet-conf/overlays/ls/gitrepo-manke.yaml
+++ b/fleet/lib/fleet-conf/overlays/ls/gitrepo-manke.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: fleet-default
 spec:
   repo: https://github.com/lsst-it/k8s-cookbook
-  branch: master
+  branch: ls_production
   keepResources: true
   paths:
-    - fleet/site/ls/cluster/manke/*
+    - fleet/s/ls/c/manke/*
   targets:
     - name: manke
       clusterName: manke

--- a/fleet/lib/fleet-conf/overlays/tu/gitrepo-pillan.yaml
+++ b/fleet/lib/fleet-conf/overlays/tu/gitrepo-pillan.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: fleet-default
 spec:
   repo: https://github.com/lsst-it/k8s-cookbook
-  branch: master
+  branch: tu_production
   keepResources: true
   paths:
-    - fleet/site/tu/cluster/pillan/*
+    - fleet/s/tu/c/pillan/*
   targets:
     - name: pillan
       clusterName: pillan


### PR DESCRIPTION
With the exception of the dev site, which will use the `master` branch. `cp_production` will be used for the `cp` site to be consistent with `lsst-it/lsst-control`.

Map of sites to github branch names:

dev: master
tu: tu_production
ls: ls_production
cp: cp_production