### PR TITLE
(fleet/velero) bump chart to 5.4.1

### DIFF
--- a/fleet/lib/velero/fleet.yaml
+++ b/fleet/lib/velero/fleet.yaml
@@ -6,7 +6,7 @@ helm:
   chart: *name
   releaseName: *name
   repo: https://vmware-tanzu.github.io/helm-charts
-  version: 4.1.0
+  version: 5.4.1
   valuesFiles:
     - values.yaml
   timeoutSeconds: 300


### PR DESCRIPTION
Resolves this error seen on k8s 1.29.2:

    k logs velero-upgrade-crds-6gj64
    Defaulted container "velero" out of: velero, kubectl (init)
    /tmp/sh: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /tmp/sh)
    /tmp/sh: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /tmp/sh)