### PR TITLE
(fleet/kube-prometheus-stack) add puppetdb sd for node exporter

### DIFF
--- a/fleet/lib/kube-prometheus-stack/overlays/pillan/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/overlays/pillan/values.yaml
@@ -23,6 +23,32 @@ prometheus:
             target_label: instance
           - target_label: __address__
             replacement: prometheus-blackbox-exporter.blackbox-exporter:9115
+      - job_name: node-exporter
+        puppetdb_sd_configs:
+          - url: "http://puppetdb.${ .ClusterLabels.site }.lsst.org:8080"
+            query: |
+              resources {
+                type = "Class" and title = "Profile::Core::Node_info" and
+                certname in resources[certname] {
+                  type = "Class" and title = "Prometheus::Node_exporter"
+                }
+              }
+            refresh_interval: 30s
+            follow_redirects: true
+            include_parameters: true
+            enable_http2: true
+            port: 9100
+        relabel_configs:
+          - source_labels: [__meta_puppetdb_certname]
+            target_label: instance
+          - source_labels: [__meta_puppetdb_environment]
+            target_label: environment
+          - source_labels: [__meta_puppetdb_parameter_site]
+            target_label: site
+          - source_labels: [__meta_puppetdb_parameter_role]
+            target_label: role
+          - source_labels: [__meta_puppetdb_parameter_cluster]
+            target_label: cluster
       - job_name: snmp-network
         metrics_path: /snmp
         params:

--- a/fleet/lib/kube-prometheus-stack/overlays/ruka/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/overlays/ruka/values.yaml
@@ -23,6 +23,32 @@ prometheus:
             target_label: instance
           - target_label: __address__
             replacement: prometheus-blackbox-exporter.blackbox-exporter:9115
+      - job_name: node-exporter-dev
+        puppetdb_sd_configs:
+          - url: "http://puppetdb.${ .ClusterLabels.site }.lsst.org:8080"
+            query: |
+              resources {
+                type = "Class" and title = "Profile::Core::Node_info" and
+                certname in resources[certname] {
+                  type = "Class" and title = "Prometheus::Node_exporter"
+                }
+              }
+            refresh_interval: 30s
+            follow_redirects: true
+            include_parameters: true
+            enable_http2: true
+            port: 9100
+        relabel_configs:
+          - source_labels: [__meta_puppetdb_certname]
+            target_label: instance
+          - source_labels: [__meta_puppetdb_environment]
+            target_label: environment
+          - source_labels: [__meta_puppetdb_parameter_site]
+            target_label: site
+          - source_labels: [__meta_puppetdb_parameter_role]
+            target_label: role
+          - source_labels: [__meta_puppetdb_parameter_cluster]
+            target_label: cluster
       - job_name: blackbox-ping-ls
         puppetdb_sd_configs:
           - url: http://puppetdb.ls.lsst.org:8080
@@ -38,6 +64,32 @@ prometheus:
             target_label: instance
           - target_label: __address__
             replacement: prometheus-blackbox-exporter.blackbox-exporter:9115
+      - job_name: node-exporter-ls
+        puppetdb_sd_configs:
+          - url: http://puppetdb.ls.lsst.org:8080
+            query: |
+              resources {
+                type = "Class" and title = "Profile::Core::Node_info" and
+                certname in resources[certname] {
+                  type = "Class" and title = "Prometheus::Node_exporter"
+                }
+              }
+            refresh_interval: 30s
+            follow_redirects: true
+            include_parameters: true
+            enable_http2: true
+            port: 9100
+        relabel_configs:
+          - source_labels: [__meta_puppetdb_certname]
+            target_label: instance
+          - source_labels: [__meta_puppetdb_environment]
+            target_label: environment
+          - source_labels: [__meta_puppetdb_parameter_site]
+            target_label: site
+          - source_labels: [__meta_puppetdb_parameter_role]
+            target_label: role
+          - source_labels: [__meta_puppetdb_parameter_cluster]
+            target_label: cluster
       - job_name: snmp-network
         metrics_path: /snmp
         params:


### PR DESCRIPTION
This includes select puppet enc data being used as prometheus labels.

Requires https://github.com/lsst-it/lsst-control/pull/1110