### PR TITLE
(ayekan) enable puppetdb http basic auth + use enc data as labels

### DIFF
--- a/fleet/lib/kube-prometheus-stack/overlays/ayekan/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/overlays/ayekan/values.yaml
@@ -4,11 +4,22 @@ prometheus:
     configMaps:
       - prometheus-snmp-csv-network
       - pdu-targets
+    secrets:
+      - puppetdb
     additionalScrapeConfigs:
       - job_name: node-exporter-dev
         puppetdb_sd_configs:
-          - url: "http://puppetdb.dev.lsst.org:8080"
-            query: "resources { type = \"Class\" and title = \"Prometheus::Node_exporter\" }"
+          - url: https://puppetdb.dev.lsst.org:8443
+            basic_auth:
+              username: svc_prometheus
+              password_file: /etc/prometheus/secrets/puppetdb/password
+            query: |
+              resources {
+                type = "Class" and title = "Profile::Core::Node_info" and
+                certname in resources[certname] {
+                  type = "Class" and title = "Prometheus::Node_exporter"
+                }
+              }
             refresh_interval: "30s"
             follow_redirects: true
             include_parameters: true
@@ -19,10 +30,25 @@ prometheus:
             target_label: instance
           - source_labels: [__meta_puppetdb_environment]
             target_label: environment
+          - source_labels: [__meta_puppetdb_parameter_site]
+            target_label: site
+          - source_labels: [__meta_puppetdb_parameter_role]
+            target_label: role
+          - source_labels: [__meta_puppetdb_parameter_cluster]
+            target_label: cluster
       - job_name: node-exporter-ls
         puppetdb_sd_configs:
-          - url: "http://puppetdb.ls.lsst.org:8080"
-            query: "resources { type = \"Class\" and title = \"Prometheus::Node_exporter\" }"
+          - url: https://puppetdb.ls.lsst.org:8443
+            basic_auth:
+              username: svc_prometheus
+              password_file: /etc/prometheus/secrets/puppetdb/password
+            query: |
+              resources {
+                type = "Class" and title = "Profile::Core::Node_info" and
+                certname in resources[certname] {
+                  type = "Class" and title = "Prometheus::Node_exporter"
+                }
+              }
             refresh_interval: "30s"
             follow_redirects: true
             include_parameters: true
@@ -34,7 +60,10 @@ prometheus:
         params:
           module: [icmp]
         puppetdb_sd_configs:
-          - url: "http://puppetdb.dev.lsst.org:8080"
+          - url: https://puppetdb.dev.lsst.org:8443
+            basic_auth:
+              username: svc_prometheus
+              password_file: /etc/prometheus/secrets/puppetdb/password
             query: "resources { type = \"Class\" and title = \"Prometheus::Node_exporter\" }"
             refresh_interval: "30s"
             follow_redirects: true
@@ -52,7 +81,10 @@ prometheus:
         params:
           module: [icmp]
         puppetdb_sd_configs:
-          - url: "http://puppetdb.ls.lsst.org:8080"
+          - url: https://puppetdb.ls.lsst.org:8443
+            basic_auth:
+              username: svc_prometheus
+              password_file: /etc/prometheus/secrets/puppetdb/password
             query: "resources { type = \"Class\" and title = \"Prometheus::Node_exporter\" }"
             refresh_interval: "30s"
             follow_redirects: true


### PR DESCRIPTION
Add the same http basic auth to ayekan as was introduced in #304 .