### PR TITLE
(fleet/multus) increase request to 64Mi; limit to 128Mi

### DIFF
--- a/fleet/lib/multus/multus-daemonset-thick.yml
+++ b/fleet/lib/multus/multus-daemonset-thick.yml
@@ -161,11 +161,11 @@ spec:
           command: [ "/usr/src/multus-cni/bin/multus-daemon" ]
           resources:
             requests:
-              cpu: "100m"
-              memory: "50Mi"
+              cpu: 100m
+              memory: 64Mi
             limits:
-              cpu: "100m"
-              memory: "50Mi"
+              cpu: 100m
+              memory: 128Mi
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
This attempts to resolve the kube-mutlus-ds pods being killed by the oom.