### PR TITLE
(yagan) fix net-attach-def's to use bridge interfaces

### DIFF
--- a/fleet/lib/multus-conf/overlays/yagan/net-attach-def-dds.yaml
+++ b/fleet/lib/multus-conf/overlays/yagan/net-attach-def-dds.yaml
@@ -8,7 +8,7 @@ spec:
   config: '{
       "cniVersion": "0.3.1",
       "type": "macvlan",
-      "master": "enp1s0f1.1201",
+      "master": "br1201",
       "mode": "bridge",
       "ipam": {
         "type": "dhcp",

--- a/fleet/lib/multus-conf/overlays/yagan/net-attach-def-macvlan-conf.yaml
+++ b/fleet/lib/multus-conf/overlays/yagan/net-attach-def-macvlan-conf.yaml
@@ -8,7 +8,7 @@ spec:
   config: '{
       "cniVersion": "0.3.1",
       "type": "macvlan",
-      "master": "enp1s0f1.1201",
+      "master": "br1201",
       "mode": "bridge",
       "ipam": {
         "type": "dhcp",


### PR DESCRIPTION
Instead of directly using vlan interface names, which vary by node.