### PR TITLE
(fleet/cnpg-system) increase mem to 192Mi/384Mi

### DIFF
--- a/fleet/lib/cnpg-system/fleet.yaml
+++ b/fleet/lib/cnpg-system/fleet.yaml
@@ -13,7 +13,7 @@ helm:
     resources:
       limits:
         cpu: 500m
-        memory: 128Mi
+        memory: 384Mi
       requests:
         cpu: 100m
-        memory: 128Mi
+        memory: 192Mi


### PR DESCRIPTION
This is to resolve the oom killing the cnpg operator.