### PR TITLE
(ruka,yagan,yepun) do not enable svc nodeports

### DIFF
--- a/fleet/lib/cnpg-cluster/overlays/ruka/cnpg-loadBalancer.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/ruka/cnpg-loadBalancer.yaml
@@ -7,19 +7,11 @@ metadata:
   annotations:
     metallb.universe.tf/loadBalancerIPs: 139.229.134.193
 spec:
-  allocateLoadBalancerNodePorts: true
-  externalTrafficPolicy: Cluster
-  internalTrafficPolicy: Cluster
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
-  - nodePort: 32509
-    port: 5432
-    protocol: TCP
-    targetPort: 5432
+    - name: postgresql
+      port: 5432
+      protocol: TCP
   selector:
     cnpg.io/cluster: cnpg-cluster
     role: primary
-  sessionAffinity: None
   type: LoadBalancer

--- a/fleet/lib/cnpg-cluster/overlays/yagan/cnpg-loadBalancer-lhn.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/yagan/cnpg-loadBalancer-lhn.yaml
@@ -7,19 +7,11 @@ metadata:
   annotations:
     metallb.universe.tf/loadBalancerIPs: 139.229.180.6
 spec:
-  allocateLoadBalancerNodePorts: true
-  externalTrafficPolicy: Cluster
-  internalTrafficPolicy: Cluster
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
-  - nodePort: 32509
-    port: 5432
-    protocol: TCP
-    targetPort: 5432
+    - name: postgres
+      port: 5432
+      protocol: TCP
   selector:
     cnpg.io/cluster: cnpg-cluster
     role: primary
-  sessionAffinity: None
   type: LoadBalancer

--- a/fleet/lib/cnpg-cluster/overlays/yagan/cnpg-loadBalancer.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/yagan/cnpg-loadBalancer.yaml
@@ -7,19 +7,11 @@ metadata:
   annotations:
     metallb.universe.tf/loadBalancerIPs: 139.229.160.157
 spec:
-  allocateLoadBalancerNodePorts: true
-  externalTrafficPolicy: Cluster
-  internalTrafficPolicy: Cluster
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
-  - nodePort: 32509
-    port: 5432
-    protocol: TCP
-    targetPort: 5432
+    - name: postgres
+      port: 5432
+      protocol: TCP
   selector:
     cnpg.io/cluster: cnpg-cluster
     role: primary
-  sessionAffinity: None
   type: LoadBalancer

--- a/fleet/lib/cnpg-cluster/overlays/yepun/cnpg-loadBalancer.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/yepun/cnpg-loadBalancer.yaml
@@ -7,19 +7,11 @@ metadata:
   annotations:
     metallb.universe.tf/loadBalancerIPs: 139.229.160.131
 spec:
-  allocateLoadBalancerNodePorts: true
-  externalTrafficPolicy: Cluster
-  internalTrafficPolicy: Cluster
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
-  - nodePort: 32509
-    port: 5432
-    protocol: TCP
-    targetPort: 5432
+    - name: postgres
+      port: 5432
+      protocol: TCP
   selector:
     cnpg.io/cluster: cnpg-cluster
     role: primary
-  sessionAffinity: None
   type: LoadBalancer


### PR DESCRIPTION
As multiple svcs with nodeport enabled with cause a port allocation conflict.

The svc's for pillan and manke were not updated as those production deployments are currently working. Those deployments should be updated when convenient.