### PR TITLE
(dev/*) bump k8s to v1.27.12-rancher1-1

### DIFF
--- a/ayekan/rke/cluster.yml
+++ b/ayekan/rke/cluster.yml
@@ -1,6 +1,4 @@
 ---
-# If you intened to deploy Kubernetes in an air-gapped environment,
-# please consult the documentation on how to configure custom RKE images.
 nodes:
 - address: ayekan01.ls.lsst.org
   hostname_override: ayekan01
@@ -30,111 +28,14 @@ nodes:
   labels:
     role: storage-node
 services:
-  etcd:
-    image: ""
-    extra_args:
-      listen-metrics-urls: http://0.0.0.0:2381
-    extra_binds: []
-    extra_env: []
-    external_urls: []
-    ca_cert: ""
-    cert: ""
-    key: ""
-    path: ""
-    uid: 0
-    gid: 0
-    snapshot: null
-    retention: ""
-    creation: ""
-    backup_config: null
-  kube-api:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
-    service_cluster_ip_range: 10.43.0.0/16
-    service_node_port_range: ""
-    pod_security_policy: false
-    always_pull_images: false
-    secrets_encryption_config: null
-    audit_log: null
-    admission_configuration: null
-    event_rate_limit: null
-  kube-controller:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
-    cluster_cidr: 10.42.0.0/16
-    service_cluster_ip_range: 10.43.0.0/16
-  scheduler:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
   kubelet:
-    image: ""
     extra_args:
       node-status-max-images: "-1"
-    extra_binds: []
-    extra_env: []
-    cluster_domain: cluster.local
-    infra_container_image: ""
-    cluster_dns_server: 10.43.0.10
-    fail_swap_on: false
-    generate_serving_certificate: false
-  kubeproxy:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
+      max-pods: 250
 network:
   plugin: canal
-  options: {}
-  mtu: 0
-  node_selector: {}
-authentication:
-  strategy: x509
-  sans: []
-  webhook: null
-addons: ""
-addons_include: []
 ssh_key_path: ~/.ssh/id_rsa
-ssh_cert_path: ""
-ssh_agent_auth: false
-authorization:
-  mode: rbac
-  options: {}
-ignore_docker_version: false
-kubernetes_version: "v1.25.9-rancher2-2"
-private_registries: []
+ignore_docker_version: true
+kubernetes_version: v1.27.12-rancher1-1
 ingress:
   provider: none
-  options: {}
-  node_selector: {}
-  extra_args: {}
-  dns_policy: ""
-  extra_envs: []
-  extra_volumes: []
-  extra_volume_mounts: []
-cluster_name: ""
-cloud_provider:
-  name: ""
-prefix_path: ""
-addon_job_timeout: 0
-bastion_host:
-  address: ""
-  port: ""
-  user: ""
-  ssh_key: ""
-  ssh_key_path: ""
-  ssh_cert: ""
-  ssh_cert_path: ""
-monitoring:
-  provider: ""
-  options: {}
-  node_selector: {}
-restore:
-  restore: false
-  snapshot_name: ""
-dns: null

--- a/kueyen/rke/cluster.yml
+++ b/kueyen/rke/cluster.yml
@@ -1,160 +1,41 @@
 ---
-# If you intened to deploy Kubernetes in an air-gapped environment,
-# please consult the documentation on how to configure custom RKE images.
 nodes:
 - address: kueyen01.dev.lsst.org
-  port: "22"
-  internal_address: ""
+  hostname_override: kueyen01
+  user: rke
   role:
   - controlplane
   - worker
   - etcd
-  hostname_override: "kueyen01"
-  user: rke
-  docker_socket: /var/run/docker.sock
-  ssh_key: ""
-  ssh_key_path: ~/.ssh/id_rsa
-  ssh_cert: ""
-  ssh_cert_path: ""
   labels:
     role: storage-node
 - address: kueyen02.dev.lsst.org
-  port: "22"
-  internal_address: ""
+  hostname_override: kueyen02
+  user: rke
   role:
   - controlplane
   - worker
   - etcd
-  hostname_override: "kueyen02"
-  user: rke
-  docker_socket: /var/run/docker.sock
-  ssh_key: ""
-  ssh_key_path: ~/.ssh/id_rsa
-  ssh_cert: ""
-  ssh_cert_path: ""
   labels:
     role: storage-node
 - address: kueyen03.dev.lsst.org
-  port: "22"
-  internal_address: ""
+  hostname_override: kueyen03
+  user: rke
   role:
   - controlplane
   - worker
   - etcd
-  hostname_override: "kueyen03"
-  user: rke
-  docker_socket: /var/run/docker.sock
-  ssh_key: ""
-  ssh_key_path: ~/.ssh/id_rsa
-  ssh_cert: ""
-  ssh_cert_path: ""
   labels:
     role: storage-node
 services:
-  etcd:
-    image: ""
-    extra_args:
-      listen-metrics-urls: http://0.0.0.0:2381
-    extra_binds: []
-    extra_env: []
-    external_urls: []
-    ca_cert: ""
-    cert: ""
-    key: ""
-    path: ""
-    uid: 0
-    gid: 0
-    snapshot: null
-    retention: ""
-    creation: ""
-    backup_config: null
-  kube-api:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
-    service_cluster_ip_range: 10.43.0.0/16
-    service_node_port_range: ""
-    pod_security_policy: false
-    always_pull_images: false
-    secrets_encryption_config: null
-    audit_log: null
-    admission_configuration: null
-    event_rate_limit: null
-  kube-controller:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
-    cluster_cidr: 10.42.0.0/16
-    service_cluster_ip_range: 10.43.0.0/16
-  scheduler:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
   kubelet:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
-    cluster_domain: cluster.local
-    infra_container_image: ""
-    cluster_dns_server: 10.43.0.10
-    fail_swap_on: false
-    generate_serving_certificate: false
-  kubeproxy:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
+    extra_args:
+      node-status-max-images: "-1"
+      max-pods: 250
 network:
   plugin: canal
-  options: {}
-  mtu: 0
-  node_selector: {}
-authentication:
-  strategy: x509
-  sans: []
-  webhook: null
-addons: ""
-addons_include: []
 ssh_key_path: ~/.ssh/id_rsa
-ssh_cert_path: ""
-ssh_agent_auth: false
-authorization:
-  mode: rbac
-  options: {}
-ignore_docker_version: false
-kubernetes_version: "v1.25.9-rancher2-2"
-private_registries: []
+ignore_docker_version: true
+kubernetes_version: v1.27.12-rancher1-1
 ingress:
   provider: none
-  options: {}
-  node_selector: {}
-  extra_args: {}
-  dns_policy: ""
-  extra_envs: []
-  extra_volumes: []
-  extra_volume_mounts: []
-cluster_name: ""
-cloud_provider:
-  name: ""
-prefix_path: ""
-addon_job_timeout: 0
-bastion_host:
-  address: ""
-  port: ""
-  user: ""
-  ssh_key: ""
-  ssh_key_path: ""
-  ssh_cert: ""
-  ssh_cert_path: ""
-monitoring:
-  provider: ""
-  options: {}
-  node_selector: {}
-restore:
-  restore: false
-  snapshot_name: ""
-dns: null

--- a/namkueyen/rke/cluster.yaml
+++ b/namkueyen/rke/cluster.yaml
@@ -1,160 +1,41 @@
 ---
-# If you intened to deploy Kubernetes in an air-gapped environment,
-# please consult the documentation on how to configure custom RKE images.
 nodes:
 - address: namkueyen01.dev.lsst.org
-  port: "22"
-  internal_address: ""
+  hostname_override: namkueyen01
+  user: rke
   role:
   - controlplane
   - worker
   - etcd
-  hostname_override: "namkueyen01"
-  user: rke
-  docker_socket: /var/run/docker.sock
-  ssh_key: ""
-  ssh_key_path: ~/.ssh/id_rsa
-  ssh_cert: ""
-  ssh_cert_path: ""
   labels:
     role: storage-node
 - address: namkueyen02.dev.lsst.org
-  port: "22"
-  internal_address: ""
+  hostname_override: namkueyen02
+  user: rke
   role:
   - controlplane
   - worker
   - etcd
-  hostname_override: "namkueyen02"
-  user: rke
-  docker_socket: /var/run/docker.sock
-  ssh_key: ""
-  ssh_key_path: ~/.ssh/id_rsa
-  ssh_cert: ""
-  ssh_cert_path: ""
   labels:
     role: storage-node
 - address: namkueyen03.dev.lsst.org
-  port: "22"
-  internal_address: ""
+  hostname_override: namkueyen03
+  user: rke
   role:
   - controlplane
   - worker
   - etcd
-  hostname_override: "namkueyen03"
-  user: rke
-  docker_socket: /var/run/docker.sock
-  ssh_key: ""
-  ssh_key_path: ~/.ssh/id_rsa
-  ssh_cert: ""
-  ssh_cert_path: ""
   labels:
     role: storage-node
 services:
-  etcd:
-    image: ""
-    extra_args:
-      listen-metrics-urls: http://0.0.0.0:2381
-    extra_binds: []
-    extra_env: []
-    external_urls: []
-    ca_cert: ""
-    cert: ""
-    key: ""
-    path: ""
-    uid: 0
-    gid: 0
-    snapshot: null
-    retention: ""
-    creation: ""
-    backup_config: null
-  kube-api:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
-    service_cluster_ip_range: 10.43.0.0/16
-    service_node_port_range: ""
-    pod_security_policy: false
-    always_pull_images: false
-    secrets_encryption_config: null
-    audit_log: null
-    admission_configuration: null
-    event_rate_limit: null
-  kube-controller:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
-    cluster_cidr: 10.42.0.0/16
-    service_cluster_ip_range: 10.43.0.0/16
-  scheduler:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
   kubelet:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
-    cluster_domain: cluster.local
-    infra_container_image: ""
-    cluster_dns_server: 10.43.0.10
-    fail_swap_on: false
-    generate_serving_certificate: false
-  kubeproxy:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
+    extra_args:
+      node-status-max-images: "-1"
+      max-pods: 250
 network:
   plugin: canal
-  options: {}
-  mtu: 0
-  node_selector: {}
-authentication:
-  strategy: x509
-  sans: []
-  webhook: null
-addons: ""
-addons_include: []
 ssh_key_path: ~/.ssh/id_rsa
-ssh_cert_path: ""
-ssh_agent_auth: false
-authorization:
-  mode: rbac
-  options: {}
-ignore_docker_version: false
-kubernetes_version: "v1.25.9-rancher2-2"
-private_registries: []
+ignore_docker_version: true
+kubernetes_version: v1.27.12-rancher1-1
 ingress:
   provider: none
-  options: {}
-  node_selector: {}
-  extra_args: {}
-  dns_policy: ""
-  extra_envs: []
-  extra_volumes: []
-  extra_volume_mounts: []
-cluster_name: ""
-cloud_provider:
-  name: ""
-prefix_path: ""
-addon_job_timeout: 0
-bastion_host:
-  address: ""
-  port: ""
-  user: ""
-  ssh_key: ""
-  ssh_key_path: ""
-  ssh_cert: ""
-  ssh_cert_path: ""
-monitoring:
-  provider: ""
-  options: {}
-  node_selector: {}
-restore:
-  restore: false
-  snapshot_name: ""
-dns: null

--- a/rancher.dev/rancher/values.yaml
+++ b/rancher.dev/rancher/values.yaml
@@ -6,7 +6,3 @@ ingress:
   extraAnnotations:
     "cert-manager.io/cluster-issuer": letsencrypt
     "kubernetes.io/ingress.class": nginx
-global:
-  cattle:
-    psp:
-      enabled: false

--- a/rancher.dev/rke/cluster.yml
+++ b/rancher.dev/rke/cluster.yml
@@ -1,6 +1,4 @@
 ---
-# If you intened to deploy Kubernetes in an air-gapped environment,
-# please consult the documentation on how to configure custom RKE images.
 nodes:
 - address: rancher01.dev.lsst.org
   hostname_override: rancher01
@@ -24,110 +22,14 @@ nodes:
   - worker
   - etcd
 services:
-  etcd:
-    image: ""
-    extra_args:
-      listen-metrics-urls: http://0.0.0.0:2381
-    extra_binds: []
-    extra_env: []
-    external_urls: []
-    ca_cert: ""
-    cert: ""
-    key: ""
-    path: ""
-    uid: 0
-    gid: 0
-    snapshot: null
-    retention: ""
-    creation: ""
-    backup_config: null
-  kube-api:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
-    service_cluster_ip_range: 10.43.0.0/16
-    service_node_port_range: ""
-    pod_security_policy: false
-    always_pull_images: false
-    secrets_encryption_config: null
-    audit_log: null
-    admission_configuration: null
-    event_rate_limit: null
-  kube-controller:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
-    cluster_cidr: 10.42.0.0/16
-    service_cluster_ip_range: 10.43.0.0/16
-  scheduler:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
   kubelet:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
-    cluster_domain: cluster.local
-    infra_container_image: ""
-    cluster_dns_server: 10.43.0.10
-    fail_swap_on: false
-    generate_serving_certificate: false
-  kubeproxy:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
+    extra_args:
+      node-status-max-images: "-1"
+      max-pods: 250
 network:
   plugin: canal
-  options: {}
-  mtu: 0
-  node_selector: {}
-authentication:
-  strategy: x509
-  sans: []
-  webhook: null
-addons: ""
-addons_include: []
 ssh_key_path: ~/.ssh/id_rsa
-ssh_cert_path: ""
-ssh_agent_auth: false
-authorization:
-  mode: rbac
-  options: {}
-ignore_docker_version: false
-kubernetes_version: "v1.25.9-rancher2-2"
-private_registries: []
+ignore_docker_version: true
+kubernetes_version: v1.27.12-rancher1-1
 ingress:
   provider: none
-  options: {}
-  node_selector: {}
-  extra_args: {}
-  dns_policy: ""
-  extra_envs: []
-  extra_volumes: []
-  extra_volume_mounts: []
-cluster_name: ""
-cloud_provider:
-  name: ""
-prefix_path: ""
-addon_job_timeout: 0
-bastion_host:
-  address: ""
-  port: ""
-  user: ""
-  ssh_key: ""
-  ssh_key_path: ""
-  ssh_cert: ""
-  ssh_cert_path: ""
-monitoring:
-  provider: ""
-  options: {}
-  node_selector: {}
-restore:
-  restore: false
-  snapshot_name: ""
-dns: null

--- a/ruka/rke/cluster.yml
+++ b/ruka/rke/cluster.yml
@@ -1,6 +1,4 @@
 ---
-# If you intened to deploy Kubernetes in an air-gapped environment,
-# please consult the documentation on how to configure custom RKE images.
 nodes:
 - address: ruka01.dev.lsst.org
   hostname_override: ruka01
@@ -57,111 +55,14 @@ nodes:
 #  labels:
 #    role: storage-node
 services:
-  etcd:
-    image: ""
-    services:
-    extra_args:
-      listen-metrics-urls: http://0.0.0.0:2381
-    extra_binds: []
-    extra_env: []
-    external_urls: []
-    ca_cert: ""
-    cert: ""
-    key: ""
-    path: ""
-    uid: 0
-    gid: 0
-    snapshot: null
-    retention: ""
-    creation: ""
-    backup_config: null
-  kube-api:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
-    service_cluster_ip_range: 10.43.0.0/16
-    service_node_port_range: ""
-    pod_security_policy: false
-    always_pull_images: false
-    secrets_encryption_config: null
-    audit_log: null
-    admission_configuration: null
-    event_rate_limit: null
-  kube-controller:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
-    cluster_cidr: 10.42.0.0/16
-    service_cluster_ip_range: 10.43.0.0/16
-  scheduler:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
   kubelet:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
-    cluster_domain: cluster.local
-    infra_container_image: ""
-    cluster_dns_server: 10.43.0.10
-    fail_swap_on: false
-    generate_serving_certificate: false
-  kubeproxy:
-    image: ""
-    extra_args: {}
-    extra_binds: []
-    extra_env: []
+    extra_args:
+      node-status-max-images: "-1"
+      max-pods: 250
 network:
   plugin: canal
-  options: {}
-  mtu: 0
-  node_selector: {}
-authentication:
-  strategy: x509
-  sans: []
-  webhook: null
-addons: ""
-addons_include: []
 ssh_key_path: ~/.ssh/id_rsa
-ssh_cert_path: ""
-ssh_agent_auth: false
-authorization:
-  mode: rbac
-  options: {}
-ignore_docker_version: false
-kubernetes_version: "v1.25.9-rancher2-2"
-private_registries: []
+ignore_docker_version: true
+kubernetes_version: v1.27.12-rancher1-1
 ingress:
   provider: none
-  options: {}
-  node_selector: {}
-  extra_args: {}
-  dns_policy: ""
-  extra_envs: []
-  extra_volumes: []
-  extra_volume_mounts: []
-cluster_name: ""
-cloud_provider:
-  name: ""
-prefix_path: ""
-addon_job_timeout: 0
-bastion_host:
-  address: ""
-  port: ""
-  user: ""
-  ssh_key: ""
-  ssh_key_path: ""
-  ssh_cert: ""
-  ssh_cert_path: ""
-monitoring:
-  provider: ""
-  options: {}
-  node_selector: {}
-restore:
-  restore: false
-  snapshot_name: ""
-dns: null


### PR DESCRIPTION
The number of allowed pods per node is increased from the default of 110 to 250.

Depends on https://github.com/lsst-it/lsst-control/pull/1127