### PR TITLE
(fleet/prometheus-stack) set the correct key for the grafana keycloak

### DIFF
--- a/fleet/lib/kube-prometheus-stack-pre/externalsecret-grafana-keycloak-credentials.yaml
+++ b/fleet/lib/kube-prometheus-stack-pre/externalsecret-grafana-keycloak-credentials.yaml
@@ -18,7 +18,7 @@ spec:
   - remoteRef:
       key: grafana-keycloak-credentials
       property: hostname
-    secretKey: keycloak_url
+    secretKey: url
   refreshInterval: 1h
   target:
     creationPolicy: Owner


### PR DESCRIPTION
As the summary mentions, this was incorrectly set in the 1password. Temporarry adding the correct key, but it should be corrected.