### PR TITLE
(konkong) increase o11y rgw quota to 1.05TiB

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-o11y.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-o11y.yaml
@@ -17,7 +17,7 @@ spec:
       dataChunks: 2
       codingChunks: 1
     quotas:
-      maxSize: 1.00Ti
+      maxSize: 1.05Ti
   preservePoolsOnDelete: false
   gateway:
     sslCertificateRef:


### PR DESCRIPTION
To allow the pool to function normally as usage is reduced.