### PR TITLE
(fleet/rook-ceph) PoC for radosgw deployment

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/ayekan/Chart.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+apiVersion: v3
 name: ayekan
 description: A Helm chart for Kubernetes
 type: application

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/Chart.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v3
+apiVersion: v2
 name: ayekan
 description: A Helm chart for Kubernetes
 type: application

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobject-exporter-demo.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobject-exporter-demo.yaml
@@ -1,0 +1,150 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStore
+metadata:
+  name: exporter-demo
+  namespace: rook-ceph
+spec:
+  metadataPool:
+    failureDomain: host
+    replicated:
+      size: 3
+  dataPool:
+    failureDomain: host
+    erasureCoded:
+      dataChunks: 2
+      codingChunks: 1
+  preservePoolsOnDelete: false
+  gateway:
+    port: 80
+    instances: 1
+    resources:
+      requests:
+        cpu: 512m
+        memory: 256Mi
+      limits:
+        memory: 256Mi
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: radosgw-usage-exporter
+  namespace: rook-ceph
+spec:
+  store: exporter-demo
+  displayName: radosgw-usage-exporter
+  capabilities:
+    bucket: read
+    metadata: read
+    usage: read
+    user: read
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: radosgw-usage-exporter
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/name: radosgw-usage-exporter
+    lsst.io/monitor: "true"
+    prometheus.io/scrape: "true"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: radosgw-usage-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: radosgw-usage-exporter
+    spec:
+      containers:
+      - image: ghcr.io/pando85/radosgw_usage_exporter:latest
+        env:
+        - name: ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: AccessKey
+              name: &userSecret rook-ceph-object-user-exporter-demo-radosgw-usage-exporter
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: SecretKey
+              name: *userSecret
+        - name: RADOSGW_SERVER
+          valueFrom:
+            secretKeyRef:
+              key: Endpoint
+              name: *userSecret
+        - name: VIRTUAL_PORT
+          value: "9242"
+        - name: STORE
+          value: eu-central-1a
+        - name: LOG_LEVEL
+          value: INFO
+        - name: TIMEOUT
+          value: "60"
+        args:
+        - --insecure
+        name: exporter
+        ports:
+        - containerPort: 9242
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 40Mi
+        livenessProbe:
+          tcpSocket:
+            port: http
+        readinessProbe:
+          tcpSocket:
+            port: http
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: radosgw-usage-exporter
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/name: radosgw-usage-exporter
+spec:
+  selector:
+    app.kubernetes.io/name: radosgw-usage-exporter
+  ports:
+  - name: http
+    port: 9242
+    protocol: TCP
+    targetPort: 9242
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: radosgw-usage-exporter
+  namespace: rook-ceph
+  labels:
+    app.kubernetes.io/name: radosgw-usage-exporter
+    lsst.io/monitor: "true"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: radosgw-usage-exporter
+  endpoints:
+  - honorLabels: true
+    interval: 90s
+    path: /metrics
+    port: http
+    scheme: http
+    scrapeTimeout: 60s


### PR DESCRIPTION
This draft is intended to work out the radosgw usage exporter deployment into the cluster.

source: https://github.com/blemmenes/radosgw_usage_exporter?tab=readme-ov-file

Realistically we probably want this deployed for all the Object stores deployed. This would require either hooking into the `cephObjectStore` value of the `rook-ceph-cluster` or an idea to brainstorm this into the `rook-ceph-conf` layout would be better.

Currently things are hardcoded, while realisitcally speaking based on the `CephObjectStore` name we could template all the other parts of the layout.