### PR TITLE
(fleet/mimir) set a default metric retention period of 2 years

### DIFF
--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -44,6 +44,7 @@ mimir:
       ingestion_burst_size: 1000000
       max_global_series_per_user: 0
       max_global_series_per_metric: 0
+      compactor_blocks_retention_period: 2y
 
 compactor:
   persistentVolume:


### PR DESCRIPTION
This change has been confirmed as working by inspecting the compactor pod logs:

    ts=2024-05-13T19:03:05.618115801Z caller=blocks_cleaner.go:629 level=info component=cleaner run_id=1715626985 task=clean_up_users user=anonymous msg="marked blocks for deletion" num_blocks=0 retention=17520h0m0s
