### PR TITLE
(fleet/rook-ceph-cluster) ignore spec.upgradeOSDRequiresHealthyPGs

### DIFF
--- a/fleet/lib/rook-ceph-cluster/fleet.yaml
+++ b/fleet/lib/rook-ceph-cluster/fleet.yaml
@@ -51,6 +51,7 @@ diff:
         - /spec/dashboard/ssl
         - /spec/disruptionManagement/manageMachineDisruptionBudgets
         - /spec/storage/useAllNodes
+        - /spec/upgradeOSDRequiresHealthyPGs
 targetCustomizations:
   - name: kueyen
     clusterName: kueyen


### PR DESCRIPTION
This was added to the rook-ceph-cluster default values.yaml with a value of false, which rook then deletes from the CephCluster resource.