### PR TITLE
(fleet/rook-ceph-cluster) fix osd provisioning; set prepareosd to 32Gi

### DIFF
--- a/fleet/lib/rook-ceph-cluster/values.yaml
+++ b/fleet/lib/rook-ceph-cluster/values.yaml
@@ -132,7 +132,7 @@ cephClusterSpec:
     prepareosd:
       limits:
         cpu: "500m"
-        memory: "400Mi"
+        memory: "32Gi"
       requests:
         cpu: "500m"
         memory: "50Mi"


### PR DESCRIPTION
Provisioning of OSDs size sizes of at least 4TiB was broken because of the memory limit being set on the osd-prepare job(s).

See: https://github.com/rook/rook/commit/a84aeebb4d7d889368b1161bb2e556a3cb695b11