### PR TITLE
(fleet/kube-prometheus-stack) add externalLabels to all clusters

### DIFF
--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -43,9 +43,6 @@ prometheus:
     externalUrl: "https://prometheus.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org"
     remoteWrite:
       - url: http://mimir-distributed-gateway.mimir:80/api/v1/push
-    externalLabels:
-      site: "${ .ClusterLabels.site }"
-      prom: "${ .ClusterLabels.site }/${ .ClusterName }"
     serviceMonitorSelectorNilUsesHelmValues: false
     podMonitorSelectorNilUsesHelmValues: false
     serviceMonitorNamespaceSelector:

--- a/fleet/lib/kube-prometheus-stack/fleet.yaml
+++ b/fleet/lib/kube-prometheus-stack/fleet.yaml
@@ -12,6 +12,12 @@ helm:
   timeoutSeconds: 600
   waitForJobs: true
   atomic: false
+  values:
+    prometheus:
+      prometheusSpec:
+        externalLabels:
+          prom_site: "${ .ClusterLabels.site }"
+          prom_cluster: "${ .ClusterName }.${ .ClusterLabels.site }"
 dependsOn:
   # XXX An "aggegrator" cluster should also depend on snmp-exporter-pre but
   # targetCustomizations for dependsOn is not implemented.


### PR DESCRIPTION
The existing `site` external label would conflict with the labels being set on node-exporter metrics discovered via puppetdb, which is why it has been renamed to `prom_site`.