### PR TITLE
(fleet/mimir) set ingress client-body-buffer-size to 10m

### DIFF
--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -189,6 +189,7 @@ gateway:
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
       kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
       nginx.ingress.kubernetes.io/backend-protocol: HTTP
       nginx.ingress.kubernetes.io/server-snippet: |
         proxy_ssl_verify off;


### PR DESCRIPTION
Resolves this warning in the ingress-nginx logs:

    2024/05/17 03:39:08 [warn] 5373#5373: *16612410 a client request body is buffered to a temporary file /tmp/nginx/client-body/0000145434, client: 10.42.0.0, server: mimir.ruka.dev.lsst.org, request: "POST /api/v1/push HTTP/2.0", host: "mimir.ruka.dev.lsst.org"