### PR TITLE
(fleet/multus) Fix htcondor to skip default route

### DIFF
--- a/fleet/lib/multus-conf/overlays/manke/net-attach-def-htcondor.yaml
+++ b/fleet/lib/multus-conf/overlays/manke/net-attach-def-htcondor.yaml
@@ -14,6 +14,7 @@ spec:
         "type": "dhcp",
         "request": [
           {
+            "SkipDefault": true,
             "option": "121"
           }
         ]

--- a/fleet/lib/multus-conf/overlays/ruka/net-attach-def-htcondor.yaml
+++ b/fleet/lib/multus-conf/overlays/ruka/net-attach-def-htcondor.yaml
@@ -14,6 +14,7 @@ spec:
         "type": "dhcp",
         "request": [
           {
+            "SkipDefault": true,
             "option": "121"
           }
         ]

--- a/fleet/lib/multus-conf/overlays/yagan/net-attach-def-htcondor.yaml
+++ b/fleet/lib/multus-conf/overlays/yagan/net-attach-def-htcondor.yaml
@@ -14,6 +14,7 @@ spec:
         "type": "dhcp",
         "request": [
           {
+            "SkipDefault": true,
             "option": "121"
           }
         ]


### PR DESCRIPTION
getting the route from the current network is messing with the name resolution inside k8s network, skipping the default will force to resolve inside k8s