### PR TITLE
(fleet/kube-prometheus-stack) disable default TargetDown prometheusrule

### DIFF
--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -8,6 +8,8 @@ defaultRules:
     lsst.io/rule: "true"
   additionalRuleLabels:
     receivers: ",squadcast,"
+  disabled:
+    TargetDown: true
 
 prometheusOperator:
   enabled: true


### PR DESCRIPTION
In order to replace it with a custom prometheusrule.