### PR TITLE
(site/ls) refactor 1pass: <cluster> -> k8s-<site> -> k8s-common

### DIFF
--- a/fleet/lib/external-secrets-conf/fleet.yaml
+++ b/fleet/lib/external-secrets-conf/fleet.yaml
@@ -26,6 +26,16 @@ targetCustomizations:
     yaml:
       overlays:
         - ruka
+  - name: antu
+    clusterName: antu
+    yaml:
+      overlays:
+        - antu
+  - name: manke
+    clusterName: manke
+    yaml:
+      overlays:
+        - manke
   - name: dev
     clusterSelector:
       matchLabels:

--- a/fleet/lib/external-secrets-conf/overlays/antu/clustersecretstore-onepassword.yaml
+++ b/fleet/lib/external-secrets-conf/overlays/antu/clustersecretstore-onepassword.yaml
@@ -9,6 +9,7 @@ spec:
     onepassword:
       connectHost: https://connect.ls.lsst.org
       vaults:
+        antu: 1
         k8s-ls: 2
         k8s-common: 3
       auth:

--- a/fleet/lib/external-secrets-conf/overlays/manke/clustersecretstore-onepassword.yaml
+++ b/fleet/lib/external-secrets-conf/overlays/manke/clustersecretstore-onepassword.yaml
@@ -9,6 +9,7 @@ spec:
     onepassword:
       connectHost: https://connect.ls.lsst.org
       vaults:
+        manke: 1
         k8s-ls: 2
         k8s-common: 3
       auth:


### PR DESCRIPTION
Cluster level vaults have only been created for:

- antu
- manke

The vaults should be created for other clusters as they are needed.