### PR TITLE
Tune Mimir resource allocation and out-of-order time window

### DIFF
--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -40,7 +40,6 @@ mimir:
       s3:
         bucket_name: "${ .ClusterName }-mimir-ruler"
     limits:
-      compactor_blocks_retention_period: 30d
       out_of_order_time_window: 30s
       ingestion_rate: 500000
       ingestion_burst_size: 1000000

--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -40,11 +40,14 @@ mimir:
       s3:
         bucket_name: "${ .ClusterName }-mimir-ruler"
     limits:
+      compactor_blocks_retention_period: 15d
       ingestion_rate: 500000
       ingestion_burst_size: 1000000
       max_global_series_per_user: 0
       max_global_series_per_metric: 0
       compactor_blocks_retention_period: 2y
+    compactor:
+      deletion_delay: 12h
 
 compactor:
   persistentVolume:
@@ -79,7 +82,7 @@ ingester:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:
-              - key: target # support for enterprise.legacyLabels
+              - key: target  # support for enterprise.legacyLabels
                 operator: In
                 values:
                   - ingester
@@ -135,7 +138,7 @@ store_gateway:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchExpressions:
-              - key: target # support for enterprise.legacyLabels
+              - key: target  # support for enterprise.legacyLabels
                 operator: In
                 values:
                   - store-gateway

--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -72,10 +72,10 @@ ingester:
   replicas: 3
   resources:
     limits:
-      memory: 12Gi
+      memory: 20Gi
     requests:
       cpu: 2
-      memory: 12Gi
+      memory: 20Gi
   topologySpreadConstraints: {}
   affinity:
     podAntiAffinity:

--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -68,14 +68,14 @@ distributor:
       memory: 5Gi
 ingester:
   persistentVolume:
-    size: 80Gi
+    size: 50Gi
   replicas: 3
   resources:
     limits:
-      memory: 20Gi
+      memory: 24Gi
     requests:
-      cpu: 2
-      memory: 20Gi
+      cpu: 3
+      memory: 24Gi
   topologySpreadConstraints: {}
   affinity:
     podAntiAffinity:

--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -51,7 +51,7 @@ mimir:
 
 compactor:
   persistentVolume:
-    size: 40Gi
+    size: 50Gi
   resources:
     limits:
       memory: 3Gi
@@ -68,7 +68,7 @@ distributor:
       memory: 5Gi
 ingester:
   persistentVolume:
-    size: 50Gi
+    size: 80Gi
   replicas: 3
   resources:
     limits:

--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -40,7 +40,8 @@ mimir:
       s3:
         bucket_name: "${ .ClusterName }-mimir-ruler"
     limits:
-      compactor_blocks_retention_period: 15d
+      compactor_blocks_retention_period: 30d
+      out_of_order_time_window: 30s
       ingestion_rate: 500000
       ingestion_burst_size: 1000000
       max_global_series_per_user: 0


### PR DESCRIPTION
Mimir got a lot of log message due to out-of-order samples being send to it. This PR configures a tiny out-of-order window for the samples to be ingested.

We also tune the Mimir pod resources to be able to handle the data ingestion that's going on.