### PR TITLE
(antu) add kube-prometheus-stack

### DIFF
--- a/fleet/lib/kube-prometheus-stack/fleet.yaml
+++ b/fleet/lib/kube-prometheus-stack/fleet.yaml
@@ -75,8 +75,8 @@ targetCustomizations:
           operator: In
           values:
             - dev
-            - ls
             - cp
+            - ls
     helm:
       values:
         crds:
@@ -85,6 +85,8 @@ targetCustomizations:
           prometheusSpec:
             remoteWrite:
               - url: https://mimir.ayekan.dev.lsst.org/api/v1/push
+              - url: https://mimir.ruka.dev.lsst.org/api/v1/push
+              - url: https://mimir.antu.ls.lsst.org/api/v1/push
   - name: tu
     clusterSelector:
       matchExpressions:

--- a/fleet/s/ls/c/antu/kube-prometheus-stack
+++ b/fleet/s/ls/c/antu/kube-prometheus-stack
@@ -1,0 +1,1 @@
+../../../../lib/kube-prometheus-stack

--- a/fleet/s/ls/c/antu/kube-prometheus-stack-pre
+++ b/fleet/s/ls/c/antu/kube-prometheus-stack-pre
@@ -1,0 +1,1 @@
+../../../../lib/kube-prometheus-stack-pre

--- a/fleet/s/ls/c/antu/prometheus-operator-crds
+++ b/fleet/s/ls/c/antu/prometheus-operator-crds
@@ -1,0 +1,1 @@
+../../../../lib/prometheus-operator-crds


### PR DESCRIPTION
This also enables shipping prom metrics from dev, ls, & cp k8s clusters to antu & ruka.