### PR TITLE
(fleet/kube-prometheus-stack) enable scrape labels on "client" clusters

### DIFF
--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -1,82 +1,9 @@
 ---
-crds:
-  enabled: false
-
-defaultRules:
-  create: true
-  labels:
-    lsst.io/rule: "true"
-  additionalRuleLabels:
-    receivers: ",squadcast,"
-  disabled:
-    TargetDown: true
-
-prometheusOperator:
-  enabled: true
-  serviceMonitor:
-    additionalLabels:
-      lsst.io/monitor: "true"
-  resources:
-    limits:
-      cpu: 1
-      memory: 128Mi
-    requests:
-      cpu: 10m
-      memory: 128Mi
-  prometheusConfigReloader:
-    resources:
-      limits:
-        cpu: 100m
-        memory: 128Mi
-      requests:
-        cpu: 10m
-        memory: 128Mi
-
 prometheus:
   prometheusSpec:
-    scrapeInterval: 30s
-    resources:
-      limits:
-        cpu: 4
-        memory: 12Gi
-      requests:
-        cpu: 1
-        memory: 12Gi
     externalUrl: "https://prometheus.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org"
     remoteWrite:
       - url: http://mimir-distributed-gateway.mimir:80/api/v1/push
-    serviceMonitorSelectorNilUsesHelmValues: false
-    podMonitorSelectorNilUsesHelmValues: false
-    serviceMonitorNamespaceSelector:
-      matchLabels:
-        lsst.io/discover: "true"
-    serviceMonitorSelector:
-      matchLabels:
-        lsst.io/monitor: "true"
-    podMonitorNamespaceSelector:
-      matchLabels:
-        lsst.io/discover: "true"
-    podMonitorSelector:
-      matchLabels:
-        lsst.io/monitor: "true"
-    ruleNamespaceSelector:
-      matchLabels:
-        lsst.io/discover: "true"
-    ruleSelector:
-      matchLabels:
-        lsst.io/rule: "true"
-    scrapeConfigNamespaceSelector:
-      matchLabels:
-        lsst.io/discover: "true"
-    scrapeConfigSelector:
-      matchLabels:
-        lsst.io/scrape: "true"
-    probeNamespaceSelector:
-      matchLabels:
-        lsst.io/discover: "true"
-    probeSelector:
-      matchLabels:
-        lsst.io/probe: "true"
   ingress:
     enabled: true
     annotations:
@@ -94,22 +21,9 @@ prometheus:
       - secretName: tls-prometheus-ingress
         hosts:
           - "prometheus.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org"
-  serviceMonitor:
-    additionalLabels:
-      lsst.io/monitor: "true"
 
 alertmanager:
-  serviceMonitor:
-    additionalLabels:
-      lsst.io/monitor: "true"
   alertmanagerSpec:
-    resources:
-      limits:
-        cpu: 1
-        memory: 512Mi
-      requests:
-        cpu: 100m
-        memory: 512Mi
     externalUrl: "https://alertmanager.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org"
     secrets:
       - alertmanager-webhooks
@@ -134,6 +48,7 @@ alertmanager:
           - "alertmanager.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org"
 
 grafana:
+  enabled: true
   serviceMonitor:
     labels:
       lsst.io/monitor: "true"
@@ -235,59 +150,3 @@ grafana:
           jsonData:
             handleGrafanaManagedAlerts: false
             implementation: prometheus
-
-# these components are not present in the Rancher clusters
-kubeScheduler:
-  enabled: false
-kubeProxy:
-  enabled: false
-kubeControllerManager:
-  enabled: false
-
-# specify the needed label for the serviceMonitor
-kubeApiServer:
-  serviceMonitor:
-    additionalLabels:
-      lsst.io/monitor: "true"
-kubelet:
-  serviceMonitor:
-    additionalLabels:
-      lsst.io/monitor: "true"
-coreDns:
-  serviceMonitor:
-    additionalLabels:
-      lsst.io/monitor: "true"
-kubeDns:
-  serviceMonitor:
-    additionalLabels:
-      lsst.io/monitor: "true"
-kubeEtcd:
-  serviceMonitor:
-    additionalLabels:
-      lsst.io/monitor: "true"
-prometheus-node-exporter:
-  resources:
-    limits:
-      cpu: 100m
-      memory: 64Mi
-    requests:
-      cpu: 100m
-      memory: 64Mi
-  prometheus:
-    monitor:
-      additionalLabels:
-        lsst.io/monitor: "true"
-kube-state-metrics:
-  resources:
-    limits:
-      cpu: 100m
-      memory: 256Mi
-    requests:
-      cpu: 10m
-      memory: 256Mi
-  prometheus:
-    monitor:
-      additionalLabels:
-        lsst.io/monitor: "true"
-  selfMonitor:
-    enabled: true

--- a/fleet/lib/kube-prometheus-stack/fleet.yaml
+++ b/fleet/lib/kube-prometheus-stack/fleet.yaml
@@ -12,12 +12,8 @@ helm:
   timeoutSeconds: 600
   waitForJobs: true
   atomic: false
-  values:
-    prometheus:
-      prometheusSpec:
-        externalLabels:
-          prom_site: "${ .ClusterLabels.site }"
-          prom_cluster: "${ .ClusterName }.${ .ClusterLabels.site }"
+  valuesFiles:
+    - values.yaml
 dependsOn:
   # XXX An "aggegrator" cluster should also depend on snmp-exporter-pre but
   # targetCustomizations for dependsOn is not implemented.
@@ -79,8 +75,6 @@ targetCustomizations:
             - ls
     helm:
       values:
-        crds:
-          enabled: false
         prometheus:
           prometheusSpec:
             remoteWrite:
@@ -96,8 +90,6 @@ targetCustomizations:
             - tu
     helm:
       values:
-        crds:
-          enabled: false
         prometheus:
           prometheusSpec:
             remoteWrite:

--- a/fleet/lib/kube-prometheus-stack/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/values.yaml
@@ -1,0 +1,155 @@
+---
+# There's are common helm values applied to all clusters (client & "aggregator" clusters)
+crds:
+  enabled: false
+
+defaultRules:
+  create: true
+  labels:
+    lsst.io/rule: "true"
+  additionalRuleLabels:
+    receivers: ",squadcast,"
+  disabled:
+    TargetDown: true
+
+prometheusOperator:
+  enabled: true
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
+  resources:
+    limits:
+      cpu: 1
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 128Mi
+  prometheusConfigReloader:
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
+
+prometheus:
+  prometheusSpec:
+    scrapeInterval: 30s
+    resources:
+      limits:
+        cpu: 4
+        memory: 12Gi
+      requests:
+        cpu: 1
+        memory: 12Gi
+    externalLabels:
+      prom_site: "${ .ClusterLabels.site }"
+      prom_cluster: "${ .ClusterName }.${ .ClusterLabels.site }"
+    serviceMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorNamespaceSelector:
+      matchLabels:
+        lsst.io/discover: "true"
+    serviceMonitorSelector:
+      matchLabels:
+        lsst.io/monitor: "true"
+    podMonitorNamespaceSelector:
+      matchLabels:
+        lsst.io/discover: "true"
+    podMonitorSelector:
+      matchLabels:
+        lsst.io/monitor: "true"
+    ruleNamespaceSelector:
+      matchLabels:
+        lsst.io/discover: "true"
+    ruleSelector:
+      matchLabels:
+        lsst.io/rule: "true"
+    scrapeConfigNamespaceSelector:
+      matchLabels:
+        lsst.io/discover: "true"
+    scrapeConfigSelector:
+      matchLabels:
+        lsst.io/scrape: "true"
+    probeNamespaceSelector:
+      matchLabels:
+        lsst.io/discover: "true"
+    probeSelector:
+      matchLabels:
+        lsst.io/probe: "true"
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
+
+alertmanager:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
+  alertmanagerSpec:
+    resources:
+      limits:
+        cpu: 1
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 512Mi
+
+grafana:
+  enabled: false
+
+# these components are not present in the Rancher clusters
+kubeScheduler:
+  enabled: false
+kubeProxy:
+  enabled: false
+kubeControllerManager:
+  enabled: false
+
+# specify the needed label for the serviceMonitor
+kubeApiServer:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
+kubelet:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
+coreDns:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
+kubeDns:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
+kubeEtcd:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
+prometheus-node-exporter:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 64Mi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+  prometheus:
+    monitor:
+      additionalLabels:
+        lsst.io/monitor: "true"
+kube-state-metrics:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 256Mi
+    requests:
+      cpu: 10m
+      memory: 256Mi
+  prometheus:
+    monitor:
+      additionalLabels:
+        lsst.io/monitor: "true"
+  selfMonitor:
+    enabled: true


### PR DESCRIPTION
At present, only manke is scraping ceph metrics and sending them to ayekan (it isn't clear why that is working). The intent was for all dev, cp, & ls clusters to be scraping and forwarding metrics to mimir on ayekan.