### PR TITLE
(pillan) fix mimir s3 fqdn

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstore-o11y.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstore-o11y.yaml
@@ -47,7 +47,7 @@ spec:
     - s3.o11y.tu.lsst.org
     secretName: rook-ceph-rgw-ingress-tls-o11y
   rules:
-  - host: s3.o11y.tu.lsst.org
+  - host: s3.o11y.pillan.tu.lsst.org
     http:
       paths:
       - path: /


### PR DESCRIPTION
This was accidentially broken by:

  https://github.com/lsst-it/k8s-cookbook/pull/416