### PR TITLE
(fleet/prometheus-operator-crds) force install

### DIFF
--- a/fleet/lib/prometheus-operator-crds/fleet.yaml
+++ b/fleet/lib/prometheus-operator-crds/fleet.yaml
@@ -8,7 +8,5 @@ helm:
   repo: https://prometheus-community.github.io/helm-charts
   version: 11.0.0
   takeOwnership: true
-  force: false
-  timeoutSeconds: 300
+  force: true  # overwrite old crds
   waitForJobs: true
-  atomic: false


### PR DESCRIPTION
To resolve this error seen when updating ancient deployments:

    ErrApplied(1) [Cluster fleet-local/local: cannot patch "alertmanagers.monitoring.coreos.com" with kind CustomResourceDefinition: CustomResourceDefinition.apiextensions.k8s.io "alertmanagers.monitoring.coreos.com" is invalid: spec.preserveUnknownFields: Invalid value: true: must be false in order to use defaults in the schema && cannot patch "prometheuses.monitoring.coreos.com" with kind CustomResourceDefinition: CustomResourceDefinition.apiextensions.k8s.io "prometheuses.monitoring.coreos.com" is invalid: spec.preserveUnknownFields: Invalid value: true: must be false in order to use defaults in the schema && cannot patch "servicemonitors.monitoring.coreos.com" with kind CustomResourceDefinition: CustomResourceDefinition.apiextensions.k8s.io "servicemonitors.monitoring.coreos.com" is invalid: spec.preserveUnknownFields: Invalid value: true: must be false in order to use defaults in the schema]