### PR TITLE
(fleet/external-secrets-conf) fix vault name for rancher clusters

### DIFF
--- a/fleet/lib/external-secrets-conf/fleet.yaml
+++ b/fleet/lib/external-secrets-conf/fleet.yaml
@@ -17,3 +17,19 @@ dependsOn:
   - selector:
       matchLabels:
         bundle: external-secrets
+targetCustomizations:
+  - name: rancher-cluster
+    clusterSelector:
+      matchExpressions:
+        # all rancher clusters have the name local and this value can not be changed
+        - key: management.cattle.io/cluster-name
+          operator: In
+          values:
+            - local
+    helm:
+      values:
+        vaults:
+          # helm merges the maps, so we need to remove the default 1 vault
+          ${ .ClusterName }.${ .ClusterLabels.site }: ~
+          # it probaly would have been easier to name the vaults local.<site>...
+          rancher.${ .ClusterLabels.site }: 1


### PR DESCRIPTION
The 1pass vaults for the "rancher" clusters are named `rancher.<site>` but rancher/fleet insistent on naming these clusters `local` within fleet.