### PR TITLE
(fleet/kube-prometheus-stack) increase grafana sidecar limit to 512Mi

### DIFF
--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -106,7 +106,7 @@ grafana:
     resources:
       limits:
         cpu: 500m
-        memory: 256Mi
+        memory: 512Mi
       requests:
         cpu: 100m
         memory: 256Mi


### PR DESCRIPTION
On the ruka cluster, both the grafana-sc-dashboard and grafana-sc-datasources containers in the grafana pod have restarted because of an Error. The cause of these restarts isn't clear. E.g.

    State:           Running
      Started:       Mon, 13 May 2024 01:01:03 -0700
    Last State:      Terminated
      Reason:        Error
      Exit Code:     1
      Started:       Sun, 12 May 2024 23:59:38 -0700
      Finished:      Mon, 13 May 2024 01:01:02 -0700
    Ready:           True
    Restart Count:   2