### PR TITLE
(fleet/*) rm atomic flag; default is false

### DIFF
--- a/fleet/lib/blackbox-exporter/fleet.yaml
+++ b/fleet/lib/blackbox-exporter/fleet.yaml
@@ -11,7 +11,6 @@ helm:
   version: 8.17.0
   timeoutSeconds: 300
   waitForJobs: true
-  atomic: false
   valuesFiles:
     - values.yaml
 dependsOn:

--- a/fleet/lib/cert-manager-conf/fleet.yaml
+++ b/fleet/lib/cert-manager-conf/fleet.yaml
@@ -9,7 +9,6 @@ helm:
   takeOwnership: true
   force: true
   waitForJobs: true
-  atomic: false
 dependsOn:
   # on pillan, fleet does not deploy cert-manager
   #- selector:

--- a/fleet/lib/cert-manager-crds/fleet.yaml
+++ b/fleet/lib/cert-manager-crds/fleet.yaml
@@ -11,4 +11,3 @@ helm:
   takeOwnership: true
   force: true
   waitForJobs: true
-  atomic: false

--- a/fleet/lib/cert-manager/fleet.yaml
+++ b/fleet/lib/cert-manager/fleet.yaml
@@ -19,7 +19,6 @@ helm:
           lsst.io/monitor: "true"
   waitForJobs: true
   timeoutSeconds: 900
-  atomic: false
 dependsOn:
   - selector:
       matchLabels:

--- a/fleet/lib/external-secrets/fleet.yaml
+++ b/fleet/lib/external-secrets/fleet.yaml
@@ -11,7 +11,6 @@ helm:
   version: 0.9.18
   timeoutSeconds: 300
   waitForJobs: true
-  atomic: false
   values:
     serviceMonitor:
       enabled: true

--- a/fleet/lib/fleet-conf/fleet.yaml
+++ b/fleet/lib/fleet-conf/fleet.yaml
@@ -5,7 +5,6 @@ labels:
   bundle: &name fleet-conf
 helm:
   releaseName: *name
-  atomic: false
 ignore:
   conditions:
     - type: Ready

--- a/fleet/lib/fluentbit/fleet.yaml
+++ b/fleet/lib/fluentbit/fleet.yaml
@@ -10,7 +10,6 @@ helm:
   takeOwnership: true
   force: true
   waitForJobs: true
-  atomic: false
 dependsOn:
   - selector:
       matchLabels:

--- a/fleet/lib/grafana-dashboards/fleet.yaml
+++ b/fleet/lib/grafana-dashboards/fleet.yaml
@@ -9,4 +9,3 @@ helm:
   takeOwnership: true
   timeoutSeconds: 300
   waitForJobs: false
-  atomic: false

--- a/fleet/lib/ingress-nginx-lhn/fleet.yaml
+++ b/fleet/lib/ingress-nginx-lhn/fleet.yaml
@@ -29,7 +29,6 @@ helm:
     rbac:
       create: true
   waitForJobs: true
-  atomic: false
 dependsOn:
   - selector:
       matchLabels:

--- a/fleet/lib/ingress-nginx/fleet.yaml
+++ b/fleet/lib/ingress-nginx/fleet.yaml
@@ -62,7 +62,6 @@ helm:
     rbac:
       create: true
   waitForJobs: true
-  atomic: false
 dependsOn:
   - selector:
       matchLabels:

--- a/fleet/lib/kube-prometheus-stack-pre/fleet.yaml
+++ b/fleet/lib/kube-prometheus-stack-pre/fleet.yaml
@@ -8,7 +8,6 @@ helm:
   releaseName: *name
   timeoutSeconds: 300
   waitForJobs: true
-  atomic: false
 dependsOn:
   - selector:
       matchLabels:

--- a/fleet/lib/kube-prometheus-stack/fleet.yaml
+++ b/fleet/lib/kube-prometheus-stack/fleet.yaml
@@ -11,7 +11,6 @@ helm:
   version: 58.7.2
   timeoutSeconds: 600
   waitForJobs: true
-  atomic: false
   valuesFiles:
     - values.yaml
 dependsOn:

--- a/fleet/lib/kyverno-conf/fleet.yaml
+++ b/fleet/lib/kyverno-conf/fleet.yaml
@@ -7,7 +7,6 @@ helm:
   takeOwnership: true
   force: true
   waitForJobs: true
-  atomic: false
 dependsOn:
   - selector:
       matchLabels:

--- a/fleet/lib/kyverno/fleet.yaml
+++ b/fleet/lib/kyverno/fleet.yaml
@@ -12,7 +12,6 @@ helm:
   version: 3.2.3
   timeoutSeconds: 300
   waitForJobs: true
-  atomic: false  # atomic was causes failures on updates?
   values:
     replicaCount: 3
     resources:

--- a/fleet/lib/metallb-conf/fleet.yaml
+++ b/fleet/lib/metallb-conf/fleet.yaml
@@ -7,7 +7,6 @@ helm:
   takeOwnership: true
   force: true
   waitForJobs: true
-  atomic: false
 dependsOn:
   - selector:
       matchLabels:

--- a/fleet/lib/metallb-demo/fleet.yaml
+++ b/fleet/lib/metallb-demo/fleet.yaml
@@ -4,7 +4,6 @@ labels:
   bundle: *name
 helm:
   releaseName: *name
-  atomic: false
   takeOwnership: true
   force: true
 dependsOn:

--- a/fleet/lib/metallb/fleet.yaml
+++ b/fleet/lib/metallb/fleet.yaml
@@ -12,7 +12,6 @@ helm:
   # daemonset rollout may take > 300s on larger clusters
   timeoutSeconds: 900
   waitForJobs: true
-  atomic: false
   values:
     controller:
       priorityClassName: system-cluster-critical

--- a/fleet/lib/mimir-pre/fleet.yaml
+++ b/fleet/lib/mimir-pre/fleet.yaml
@@ -9,7 +9,6 @@ helm:
   takeOwnership: true
   timeoutSeconds: 300
   waitForJobs: false
-  atomic: false
 dependsOn:
   - selector:
       matchLabels:

--- a/fleet/lib/mimir/fleet.yaml
+++ b/fleet/lib/mimir/fleet.yaml
@@ -12,7 +12,6 @@ helm:
   version: 5.3.0
   timeoutSeconds: 600
   waitForJobs: true
-  atomic: false
   valuesFiles:
     - values.yaml
 dependsOn:

--- a/fleet/lib/multus-conf/fleet.yaml
+++ b/fleet/lib/multus-conf/fleet.yaml
@@ -7,7 +7,6 @@ helm:
   takeOwnership: true
   force: true
   waitForJobs: true
-  atomic: false
 dependsOn:
   - selector:
       matchLabels:

--- a/fleet/lib/multus-demo/fleet.yaml
+++ b/fleet/lib/multus-demo/fleet.yaml
@@ -6,7 +6,6 @@ helm:
   releaseName: *name
   takeOwnership: true
   waitForJobs: true
-  atomic: false
 dependsOn:
   - selector:
       matchLabels:

--- a/fleet/lib/multus/fleet.yaml
+++ b/fleet/lib/multus/fleet.yaml
@@ -7,4 +7,3 @@ helm:
   takeOwnership: true  # pre-fleet deployments do not use helm
   timeoutSeconds: 300
   waitForJobs: true
-  atomic: false

--- a/fleet/lib/opensearch-logging/fleet.yaml
+++ b/fleet/lib/opensearch-logging/fleet.yaml
@@ -10,7 +10,6 @@ helm:
   takeOwnership: true
   force: true
   waitForJobs: true
-  atomic: false
 dependsOn:
   - selector:
       matchLabels:

--- a/fleet/lib/opensearch-operator/fleet.yaml
+++ b/fleet/lib/opensearch-operator/fleet.yaml
@@ -15,4 +15,3 @@ helm:
     manager:
       logLevel: warn
   timeoutSeconds: 900
-  atomic: true

--- a/fleet/lib/rook-ceph-cluster/fleet.yaml
+++ b/fleet/lib/rook-ceph-cluster/fleet.yaml
@@ -13,7 +13,6 @@ helm:
     - values.yaml
   timeoutSeconds: 3600
   waitForJobs: true
-  atomic: false  # rollback problematic
 dependsOn:
   - selector:
       matchLabels:

--- a/fleet/lib/rook-ceph-conf/fleet.yaml
+++ b/fleet/lib/rook-ceph-conf/fleet.yaml
@@ -8,7 +8,6 @@ helm:
   takeOwnership: true
   timeoutSeconds: 3600
   waitForJobs: false
-  atomic: false
 dependsOn:
   - selector:
       matchLabels:

--- a/fleet/lib/rook-ceph-demo/fleet.yaml
+++ b/fleet/lib/rook-ceph-demo/fleet.yaml
@@ -7,7 +7,6 @@ helm:
   takeOwnership: true
   timeoutSeconds: 300
   waitForJobs: false
-  atomic: false
 dependsOn:
   - selector:
       matchLabels:

--- a/fleet/lib/rook-ceph/fleet.yaml
+++ b/fleet/lib/rook-ceph/fleet.yaml
@@ -12,7 +12,6 @@ helm:
   valuesFiles:
     - values.yaml
   waitForJobs: false
-  atomic: false
 dependsOn:
   - selector:
     matchLabels:

--- a/fleet/lib/snmp-exporter-pre/fleet.yaml
+++ b/fleet/lib/snmp-exporter-pre/fleet.yaml
@@ -8,7 +8,6 @@ helm:
   releaseName: prometheus-snmp-exporter-pre
   timeoutSeconds: 300
   waitForJobs: true
-  atomic: false
   values:
     site: "${ .ClusterLabels.site }"
 dependsOn:

--- a/fleet/lib/snmp-exporter/fleet.yaml
+++ b/fleet/lib/snmp-exporter/fleet.yaml
@@ -11,7 +11,6 @@ helm:
   version: 5.4.0
   timeoutSeconds: 300
   waitForJobs: true
-  atomic: false
   valuesFiles:
     - values.yaml
 dependsOn:

--- a/fleet/lib/strimzi-kafka-dashboards/fleet.yaml
+++ b/fleet/lib/strimzi-kafka-dashboards/fleet.yaml
@@ -9,4 +9,3 @@ helm:
   takeOwnership: true
   timeoutSeconds: 300
   waitForJobs: false
-  atomic: false

--- a/fleet/lib/velero-conf/fleet.yaml
+++ b/fleet/lib/velero-conf/fleet.yaml
@@ -7,7 +7,6 @@ helm:
   takeOwnership: true
   force: true
   waitForJobs: true
-  atomic: false
 dependsOn:
   - selector:
       matchLabels:

--- a/fleet/lib/velero/fleet.yaml
+++ b/fleet/lib/velero/fleet.yaml
@@ -11,7 +11,6 @@ helm:
     - values.yaml
   timeoutSeconds: 300
   waitForJobs: true
-  atomic: false
 dependsOn:
   - selector:
       matchLabels:


### PR DESCRIPTION
And it seems that having atomic set may (???) cause fleet to forever retry upgrading a release.