### PR TITLE
(fleet/mimir) increase distributor mem to 12Gi

### DIFF
--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -62,10 +62,10 @@ distributor:
   replicas: 2
   resources:
     limits:
-      memory: 5Gi
+      memory: 12Gi
     requests:
       cpu: 1
-      memory: 5Gi
+      memory: 12Gi
 ingester:
   persistentVolume:
     size: 50Gi


### PR DESCRIPTION
To resolve distributor pods being OOMKilled on ruka:

    mimir-distributed-distributor-7767d66476-cdh6f         0/1     OOMKilled     1 (61s ago)     2m4s
    mimir-distributed-distributor-7767d66476-cgf4b         0/1     OOMKilled     1 (72s ago)     2m18s

Increasinig the limit to 8Gi was tested and pods were still getting OOMKilled.