### PR TITLE
(fleet/mimir) increase ingester pvc size to 100Gi

### DIFF
--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -68,7 +68,7 @@ distributor:
       memory: 12Gi
 ingester:
   persistentVolume:
-    size: 50Gi
+    size: 100Gi
   replicas: 3
   resources:
     limits:


### PR DESCRIPTION
This error has been observed in the ingester logs on ruka while processing WAL logs:

    ts=2024-05-31T16:28:20.612605482Z caller=head.go:819 level=info user=anonymous msg="WAL segment loaded" segment=12510 maxSegment=12605
    panic: preallocate: no space left on device

    goroutine 606 [running]:
    github.com/prometheus/prometheus/tsdb.handleChunkWriteError({0x31cb7e0, 0xc280674e40})
            /__w/mimir/mimir/vendor/github.com/prometheus/prometheus/tsdb/head_append.go:1529 +0x5c
    github.com/prometheus/prometheus/tsdb/chunks.(*chunkWriteQueue).processJob(0xc0009158c0, {0x1, 0x1fa37f2, 0x18fcca80617, 0x18fcccd8f77, {0x31f2a40, 0xc21a82c380}, 0x4200000008, 0x0, 0x2c32f90})
            /__w/mimir/mimir/vendor/github.com/prometheus/prometheus/tsdb/chunks/chunk_write_queue.go:139 +0x82
    github.com/prometheus/prometheus/tsdb/chunks.(*chunkWriteQueue).start.func1()
            /__w/mimir/mimir/vendor/github.com/prometheus/prometheus/tsdb/chunks/chunk_write_queue.go:127 +0xa7
    created by github.com/prometheus/prometheus/tsdb/chunks.(*chunkWriteQueue).start in goroutine 59
            /__w/mimir/mimir/vendor/github.com/prometheus/prometheus/tsdb/chunks/chunk_write_queue.go:118 +0x66

Note that applying this change seems to require manually deleting the pv/pvs created by the mimir-distributed-ingester-zone-[abc] sts.