### PR TITLE
(ccs-influxdb/grafana) into fleet dev/kueyen

### DIFF
--- a/fleet/lib/ccs-grafana/base/externalsecret-grafana.yaml
+++ b/fleet/lib/ccs-grafana/base/externalsecret-grafana.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-credentials
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  data:
+    - secretKey: admin-user
+      remoteRef:
+        key: ccs-grafana
+        property: username
+    - secretKey: admin-password
+      remoteRef:
+        key: ccs-grafana
+        property: password

--- a/fleet/lib/ccs-grafana/base/kustomization.yaml
+++ b/fleet/lib/ccs-grafana/base/kustomization.yaml
@@ -1,0 +1,3 @@
+---
+resources:
+  - externalsecret-grafana.yaml

--- a/fleet/lib/ccs-grafana/fleet.yaml
+++ b/fleet/lib/ccs-grafana/fleet.yaml
@@ -1,0 +1,19 @@
+---
+defaultNamespace: ccs-monitor
+labels:
+  bundle: ccs-grafana
+kustomize:
+  dir: base
+helm:
+  chart: &chart grafana
+  releaseName: *chart
+  repo: https://grafana.github.io/helm-charts
+  version: 7.3.11
+  timeoutSeconds: 300
+  waitForJobs: true
+  valuesFiles:
+    - values.yaml
+dependsOn:
+  - selector:
+      matchLabels:
+        bundle: ccs-influxdb

--- a/fleet/lib/ccs-grafana/values.yaml
+++ b/fleet/lib/ccs-grafana/values.yaml
@@ -1,0 +1,59 @@
+---
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - ccs-grafana.${ .ClusterLabels.site }.lsst.org
+  tls:
+    - secretName: grafana-tls
+      hosts:
+        - ccs-grafana.${ .ClusterLabels.site }.lsst.org
+
+rbac:
+  create: true
+  namespaced: true
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+persistence:
+  type: pvc
+  enabled: true
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+
+admin:
+  existingSecret: grafana-credentials
+  userKey: admin-user
+  passwordKey: admin-password
+
+envValueFrom:
+  INFLUXDB_USERNAME:
+    secretKeyRef:
+      name: influxdb
+      key: influxdb-user
+  INFLUXDB_PASSWORD:
+    secretKeyRef:
+      name: influxdb
+      key: influxdb-password
+
+datasources:
+  grafana.yaml:
+    apiVersion: 1
+    datasources:
+      - name: InfluxDB
+        type: influxdb
+        url: http://influxdb.ccs-monitor:8086
+        access: proxy
+        isDefault: true
+        database: grafana
+        user: ${`${INFLUXDB_USERNAME}`}
+        password: ${`${INFLUXDB_PASSWORD}`}

--- a/fleet/lib/ccs-influxdb/base/externalsecret-influxdb.yaml
+++ b/fleet/lib/ccs-influxdb/base/externalsecret-influxdb.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: influxdb
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  data:
+    - secretKey: influxdb-username
+      remoteRef:
+        key: ccs-influxdb
+        property: username
+    - secretKey: influxdb-password
+      remoteRef:
+        key: ccs-influxdb
+        property: password

--- a/fleet/lib/ccs-influxdb/base/kustomization.yaml
+++ b/fleet/lib/ccs-influxdb/base/kustomization.yaml
@@ -1,0 +1,3 @@
+---
+resources:
+  - externalsecret-influxdb.yaml

--- a/fleet/lib/ccs-influxdb/fleet.yaml
+++ b/fleet/lib/ccs-influxdb/fleet.yaml
@@ -1,0 +1,15 @@
+---
+defaultNamespace: ccs-monitor
+labels:
+  bundle: ccs-influxdb
+kustomize:
+  dir: base
+helm:
+  chart: &chart influxdb
+  releaseName: *chart
+  repo: https://helm.influxdata.com/
+  version: 4.12.5
+  timeoutSeconds: 300
+  waitForJobs: true
+  valuesFiles:
+    - values.yaml

--- a/fleet/lib/ccs-influxdb/values.yaml
+++ b/fleet/lib/ccs-influxdb/values.yaml
@@ -1,0 +1,49 @@
+---
+ingress:
+  enabled: true
+  tls: true
+  secretName: influxdb-tls
+  hostname: ccs-influxdb.${ .ClusterLabels.site }.lsst.org
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  path: /
+
+persistence:
+  enabled: true
+  accessMode: ReadWriteOnce
+  size: 8Gi
+
+influxdb:
+  authEnabled: true
+
+setDefaultUser:
+  enabled: true
+  user:
+    existingSecret: influxdb
+    privileges: WITH ALL PRIVILEGES
+
+resources:
+  requests:
+    memory: 256Mi
+    cpu: 500m
+  limits:
+    memory: 1Gi
+    cpu: "1"
+
+https:
+  enabled: true
+  cert:
+    secretName: influxdb-tls
+
+env:
+  - name: INFLUXDB_HTTP_AUTH_ENABLED
+    value: true
+  - name: INFLUXDB_REPORTING_DISABLED
+    value: true
+
+initScripts:
+  enabled: true
+  scripts:
+    init.iql: |+
+      CREATE DATABASE grafana

--- a/fleet/s/dev/c/kueyen/ccs-grafana
+++ b/fleet/s/dev/c/kueyen/ccs-grafana
@@ -1,0 +1,1 @@
+../../../../lib/ccs-grafana

--- a/fleet/s/dev/c/kueyen/ccs-influxdb
+++ b/fleet/s/dev/c/kueyen/ccs-influxdb
@@ -1,0 +1,1 @@
+../../../../lib/ccs-influxdb


### PR DESCRIPTION
This adds an infludb and grafana instance to `kueyen`, soon `manke` and `yepun` will follow this.