### PR TITLE
(.gitignore) allow values.yaml to be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 creds.sh
 secret.yaml
-values.yaml
 template.yaml
 **/snmp-generator/mibs


### PR DESCRIPTION
This was useful when secrets were being inserted into helm values.yaml files but it is now generally a source of errors with fleet/helm values.yaml accidentally not being committed to the repo.