### PR TITLE
(fleet/kube-prometheus-stack) enable remoteWrite retry on http429

### DIFF
--- a/fleet/lib/kube-prometheus-stack/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/values.yaml
@@ -78,6 +78,8 @@ prometheus:
     probeSelector:
       matchLabels:
         lsst.io/probe: "true"
+    queueConfig:
+      retryOnRateLimit: true
   serviceMonitor:
     additionalLabels:
       lsst.io/monitor: "true"


### PR DESCRIPTION
RemoteWrite clients of both ruka & antu have been getting HTTP 429s.  Enabling this feature is supposed to enable the prometheus instance to retry the remoteWrite.

    ts=2024-06-03T22:09:41.128Z caller=dedupe.go:112 component=remote level=error remote_name=43e475 url=https://mimir.ruka.dev.lsst.org/api/v1/push msg="non-recoverable error" count=1975 exemplarCount=0 err="server returned HTTP status 429 Too Many Requests: the request has been rejected because the tenant exceeded the ingestion rate limit, set to 500000 items/s with a maximum allowed burst of 1000000. This limit is applied on the total number of samples, exemplars and metadata received across all distributors (err-mimir-tenant-max-ingestion-rate). To adjust the related per-tenant limits, configure -distributor.ingestion-rate-limit and -distributor.ingestion-burst-size, or contact your service administrator."

    ts=2024-06-04T21:45:55.900Z caller=dedupe.go:112 component=remote level=error remote_name=033e74 url=https://mimir.antu.ls.lsst.org/api/v1/push msg="non-recoverable error" count=2000 exemplarCount=0 err="server returned HTTP status 429 Too Many Requests: the request has been rejected because the tenant exceeded the ingestion rate limit, set to 500000 items/s with a maximum allowed burst of 1000000. This limit is applied on the total number of samples, exemplars and metadata received across all distributors (err-mimir-tenant-max-ingestion-rate). To adjust the related per-tenant limits, configure -distributor.ingestion-rate-limit and -distributor.ingestion-burst-size, or contact your service administrator."