### PR TITLE
(fleet/mimir) increase mimir distributor rate limits to 1M/2M

### DIFF
--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -41,8 +41,8 @@ mimir:
         bucket_name: "${ .ClusterName }-mimir-ruler"
     limits:
       out_of_order_time_window: 30s
-      ingestion_rate: 500000
-      ingestion_burst_size: 1000000
+      ingestion_rate: 1000000
+      ingestion_burst_size: 2000000
       max_global_series_per_user: 0
       max_global_series_per_metric: 0
       compactor_blocks_retention_period: 2y


### PR DESCRIPTION
To resolve these error messages seen on from prometheus instances writing to ruka & antu.

    ts=2024-06-04T21:45:55.900Z caller=dedupe.go:112 component=remote level=error remote_name=033e74 url=https://mimir.antu.ls.lsst.org/api/v1/push msg="non-recoverable error" count=2000 exemplarCount=0 err="server returned HTTP status 429 Too Many Requests: the request has been rejected because the tenant exceeded the ingestion rate limit, set to 500000 items/s with a maximum allowed burst of 1000000. This limit is applied on the total number of samples, exemplars and metadata received across all distributors (err-mimir-tenant-max-ingestion-rate). To adjust the related per-tenant limits, configure -distributor.ingestion-rate-limit and -distributor.ingestion-burst-size, or contact your service administrator."