### PR TITLE
(fleet/mimir) increase compactor disk size to 100Gi

### DIFF
--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -51,7 +51,7 @@ mimir:
 
 compactor:
   persistentVolume:
-    size: 50Gi
+    size: 100Gi
   resources:
     limits:
       memory: 3Gi


### PR DESCRIPTION
To resolve this error message seen on ruka:

    ts=2024-06-05T18:21:04.930841052Z caller=bucket_compactor.go:256 level=error component=compactor user=anonymous groupKey=0@17241709254077376921-merge--1717200000000-1717286400000 minTime="2024-06-01 00:00:00 +0000 UTC" maxTime="2024-06-02 00:00:00 +0000 UTC" msg="compaction job failed" duration=15m6.473521261s duration_ms=906473 err="compact blocks 01HZAAF4WA2CA82NKYN5ZH05Z9,01HZBDNFQ2N0JA57D6TPYQSB8Q: 3 errors: preallocate: no space left on device; sync /data/compact/0@17241709254077376921-merge--1717200000000-1717286400000/01HZMSKK57DZXZP59M2T5QB4QE.tmp-for-creation/chunks/000029: file already closed; write /data/compact/0@17241709254077376921-merge--1717200000000-1717286400000/01HZMSKK57DZXZP59M2T5QB4QE.tmp-for-creation/index_tmp_p: no space left on device"