### PR TITLE
(fleet/mimir) disable zoneAwareReplication

### DIFF
--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -98,7 +98,7 @@ ingester:
           topologyKey: kubernetes.io/hostname
 
   zoneAwareReplication:
-    topologyKey: kubernetes.io/hostname
+    enabled: false
 querier:
   replicas: 1
   resources:
@@ -153,8 +153,7 @@ store_gateway:
                   - store-gateway
           topologyKey: kubernetes.io/hostname
   zoneAwareReplication:
-    topologyKey: kubernetes.io/hostname
-
+    enabled: false
 ## caching components
 admin-cache:
   enabled: true


### PR DESCRIPTION
We don't currently implement ceph availability zones and have no plans to do so.  The zoneAwareReplication functionality in the mimir chart is largely cosmetic in that it will create multiple sts, zone per configured zone, instead of a single sts with multiple instances.  However, when scaling the number of replicas of a service up or down, the full set of zones needs to be manual enumerated and it seems like the minimum number is 3 and we would like to be able to use fewer instances on dev clusters.