### PR TITLE
(fleet/mimir) change ingestor replication_factor to 2

### DIFF
--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -48,6 +48,9 @@ mimir:
       compactor_blocks_retention_period: 2y
     compactor:
       deletion_delay: 12h
+    ingester:
+      ring:
+        replication_factor: 2
 
 compactor:
   persistentVolume:


### PR DESCRIPTION
When running 3 ingestor instances and requiring 3 replicas any distriburance to an ingestor pod causes metrics to stop being accepted. This includes rollouts, drains, and node failure.  In order to support operators the number of replicas should always be at least 1 less than the number of ingestor instances.

Changing from 3 to 2 replicas also reduces the ammount of write amplication.