### PR TITLE
(site/ls) bump rke to v1.28.9-rancher1-1

### DIFF
--- a/gaw/rke/cluster.yml
+++ b/gaw/rke/cluster.yml
@@ -53,6 +53,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.27.12-rancher1-1
+kubernetes_version: v1.28.9-rancher1-1
 ingress:
   provider: none

--- a/konkong/rke/cluster.yml
+++ b/konkong/rke/cluster.yml
@@ -35,6 +35,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.27.12-rancher1-1
+kubernetes_version: v1.28.9-rancher1-1
 ingress:
   provider: none

--- a/luan/rke/cluster.yml
+++ b/luan/rke/cluster.yml
@@ -53,6 +53,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.27.12-rancher1-1
+kubernetes_version: v1.28.9-rancher1-1
 ingress:
   provider: none

--- a/manke/rke/cluster.yml
+++ b/manke/rke/cluster.yml
@@ -90,6 +90,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.27.12-rancher1-1
+kubernetes_version: v1.28.9-rancher1-1
 ingress:
   provider: none

--- a/rancher.ls/rke/cluster.yml
+++ b/rancher.ls/rke/cluster.yml
@@ -28,6 +28,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.27.12-rancher1-1
+kubernetes_version: v1.28.9-rancher1-1
 ingress:
   provider: none


### PR DESCRIPTION
Bumping k8s clusters to 1.28.9 on LS