### PR TITLE
(rancher.*) convert onepassword-connect install to be credentials only

### DIFF
--- a/rancher.cp/onepassword/.gitignore
+++ b/rancher.cp/onepassword/.gitignore
@@ -1,1 +1,2 @@
 1password-credentials.json
+secret-op-credentials.yaml

--- a/rancher.cp/onepassword/fetch-credentials.sh
+++ b/rancher.cp/onepassword/fetch-credentials.sh
@@ -5,4 +5,17 @@ set -e
 if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
   eval "$(op signin)"
 fi
-op read "op://1pass connect/connect.cp.lsst.org Credentials File/1password-credentials.json" --out-file 1password-credentials.json
+ONEPASS_CREDS="$(op read "op://1pass connect/connect.cp.lsst.org Credentials File/1password-credentials.json")"
+
+cat > secret-op-credentials.yaml <<END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: op-credentials
+  namespace: onepassword-connect
+type: Opaque
+# The credentials end up being double base64 encoded...
+stringData:
+  1password-credentials.json: $(echo "${ONEPASS_CREDS}" | base64 -w 0)
+END

--- a/rancher.dev/onepassword/.gitignore
+++ b/rancher.dev/onepassword/.gitignore
@@ -1,1 +1,2 @@
 1password-credentials.json
+secret-op-credentials.yaml

--- a/rancher.dev/onepassword/fetch-credentials.sh
+++ b/rancher.dev/onepassword/fetch-credentials.sh
@@ -5,4 +5,17 @@ set -e
 if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
   eval "$(op signin)"
 fi
-op read "op://1pass connect/connect.dev.lsst.org Credentials File/1password-credentials.json" --out-file 1password-credentials.json
+ONEPASS_CREDS="$(op read "op://1pass connect/connect.dev.lsst.org Credentials File/1password-credentials.json")"
+
+cat > secret-op-credentials.yaml <<END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: op-credentials
+  namespace: onepassword-connect
+type: Opaque
+# The credentials end up being double base64 encoded...
+stringData:
+  1password-credentials.json: $(echo "${ONEPASS_CREDS}" | base64 -w 0)
+END

--- a/rancher.ls/onepassword/.gitignore
+++ b/rancher.ls/onepassword/.gitignore
@@ -1,1 +1,2 @@
 1password-credentials.json
+secret-op-credentials.yaml

--- a/rancher.ls/onepassword/fetch-credentials.sh
+++ b/rancher.ls/onepassword/fetch-credentials.sh
@@ -5,4 +5,17 @@ set -e
 if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
   eval "$(op signin)"
 fi
-op read "op://1pass connect/connect.ls.lsst.org Credentials File/1password-credentials.json" --out-file 1password-credentials.json
+ONEPASS_CREDS="$(op read "op://1pass connect/connect.ls.lsst.org Credentials File/1password-credentials.json")"
+
+cat > secret-op-credentials.yaml <<END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: op-credentials
+  namespace: onepassword-connect
+type: Opaque
+# The credentials end up being double base64 encoded...
+stringData:
+  1password-credentials.json: $(echo "${ONEPASS_CREDS}" | base64 -w 0)
+END

--- a/rancher.tu/onepassword/.gitignore
+++ b/rancher.tu/onepassword/.gitignore
@@ -1,1 +1,2 @@
 1password-credentials.json
+secret-op-credentials.yaml

--- a/rancher.tu/onepassword/fetch-credentials.sh
+++ b/rancher.tu/onepassword/fetch-credentials.sh
@@ -5,4 +5,17 @@ set -e
 if ! env | grep OP_SESSION_ > /dev/null 2>&1; then
   eval "$(op signin)"
 fi
-op read "op://1pass connect/connect.tu.lsst.org Credentials File/1password-credentials.json" --out-file 1password-credentials.json
+ONEPASS_CREDS="$(op read "op://1pass connect/connect.tu.lsst.org Credentials File/1password-credentials.json")"
+
+cat > secret-op-credentials.yaml <<END
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: op-credentials
+  namespace: onepassword-connect
+type: Opaque
+# The credentials end up being double base64 encoded...
+stringData:
+  1password-credentials.json: $(echo "${ONEPASS_CREDS}" | base64 -w 0)
+END

--- a/template/onepassword/README.md
+++ b/template/onepassword/README.md
@@ -6,4 +6,4 @@ Deployment
 
 Run the `fetch-credentials.sh` script to download the 1pass access token.  Note the `op` CLI must be installed and configured.
 
-Once the `1password-credentials.json` file is present, run the `onepassword-connect.sh` script.
+Once the `secret-op-credentials.yaml` file is present, run the `onepassword-connect.sh` script.

--- a/template/onepassword/onepassword-connect.sh
+++ b/template/onepassword/onepassword-connect.sh
@@ -2,13 +2,5 @@
 
 set -ex
 
-helm repo add onepassword-connect https://1password.github.io/connect-helm-charts
-helm repo update
-
-helm upgrade --install \
-  onepassword-connect onepassword-connect/connect \
-  --create-namespace --namespace onepassword-connect \
-  --version v1.14.0 \
-  --atomic \
-  --set-file connect.credentials=1password-credentials.json \
-  -f ./values.yaml
+kubectl create namespace onepassword-connect --dry-run=client -o yaml | kubectl apply --server-side -f -
+kubectl apply --server-side -f secret-op-credentials.yaml


### PR DESCRIPTION
Fleet will install / upgrade the onepassword-connect chart going forward.  As the credentials are being installed "manually", they will not be owned by the currently installed chart release and will not be uninstalled when the chart release is upgraded by fleet.