### PR TITLE
(fleet/snmp-exporter-pre) enable interpolation of snmpLsstCommunity

### DIFF
--- a/fleet/lib/snmp-exporter-pre/fleet.yaml
+++ b/fleet/lib/snmp-exporter-pre/fleet.yaml
@@ -10,6 +10,11 @@ helm:
   waitForJobs: true
   values:
     site: ${ .ClusterLabels.site }
+    community:
+      snmpRubinCommunity:
+        enabled: true
+      snmpLsstCommunity:
+        enabled: true
 dependsOn:
   - selector:
       matchLabels:
@@ -17,11 +22,6 @@ dependsOn:
 targetCustomizations:
   - name: pillan
     clusterName: pillan
-    helm:
-      values:
-        community:
-          snmpRubinCommunity:
-            enabled: true
   - name: default
     clusterSelector:
       matchLabels:
@@ -32,10 +32,3 @@ targetCustomizations:
             - dev
             - ls
             - cp
-    helm:
-      values:
-        community:
-          snmpRubinCommunity:
-            enabled: true
-          snmpLsstCommunity:
-            enabled: true


### PR DESCRIPTION
It seems that recent release of external-secrets has changed behavior and it is now an error to have templated values in a cm template that do not have a value to interpolate.