### PR TITLE
(fleet/kube-prometheus-stack) use a ceph backed pvc for prometheus data

### DIFF
--- a/fleet/lib/kube-prometheus-stack/fleet.yaml
+++ b/fleet/lib/kube-prometheus-stack/fleet.yaml
@@ -47,6 +47,7 @@ targetCustomizations:
     clusterName: pillan
     helm:
       valuesFiles:
+        - pvc/values.yaml
         - aggregator/values.yaml
         - ldap/values.yaml
         - overlays/pillan/values.yaml
@@ -54,6 +55,7 @@ targetCustomizations:
     clusterName: ruka
     helm:
       valuesFiles:
+        - pvc/values.yaml
         - aggregator/values.yaml
         - ldap/values.yaml
         - overlays/ruka/values.yaml
@@ -61,26 +63,67 @@ targetCustomizations:
     clusterName: ayekan
     helm:
       valuesFiles:
+        - pvc/values.yaml
         - aggregator/values.yaml
         - overlays/ayekan/values.yaml
-  - name: default
+  # the rancher clusters don't have ceph
+  - name: rancher-cl
     clusterSelector:
       matchExpressions:
         - key: site
           operator: In
           values:
-            - dev
             - cp
+            - dev
             - ls
+        - key: management.cattle.io/cluster-name
+          operator: In
+          values:
+            - local
     helm:
       values:
         prometheus:
           prometheusSpec:
-            remoteWrite:
+            remoteWrite: &cl-remotewrite
               - url: https://mimir.ayekan.dev.lsst.org/api/v1/push
               - url: https://mimir.ruka.dev.lsst.org/api/v1/push
               - url: https://mimir.antu.ls.lsst.org/api/v1/push
-  - name: tu
+  - name: default-cl
+    clusterSelector:
+      matchExpressions:
+        - key: site
+          operator: In
+          values:
+            - cp
+            - dev
+            - ls
+    helm:
+      valuesFiles:
+        - pvc/values.yaml
+      values:
+        prometheus:
+          prometheusSpec:
+            remoteWrite:
+              << *cl-remotewrite
+  # the rancher clusters don't have ceph
+  - name: rancher-tu
+    clusterSelector:
+      matchExpressions:
+        - key: site
+          operator: In
+          values:
+            - tu
+        - key: management.cattle.io/cluster-name
+          operator: In
+          values:
+            - local
+    helm:
+      values:
+        prometheus:
+          prometheusSpec:
+            remoteWrite: &tu-remotewrite
+              - url: https://mimir.pillan.tu.lsst.org/api/v1/push
+  - name: default-tu
     clusterSelector:
       matchExpressions:
         - key: site
@@ -88,8 +131,10 @@ targetCustomizations:
           values:
             - tu
     helm:
+      valuesFiles:
+        - pvc/values.yaml
       values:
         prometheus:
           prometheusSpec:
             remoteWrite:
-              - url: https://mimir.pillan.tu.lsst.org/api/v1/push
+              << *tu-remotewrite

--- a/fleet/lib/kube-prometheus-stack/pvc/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/pvc/values.yaml
@@ -1,0 +1,11 @@
+---
+prometheus:
+  prometheusSpec:
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          accessModes: [ReadWriteOnce]
+          storageClassName: rook-ceph-block
+          resources:
+            requests:
+              storage: 50Gi


### PR DESCRIPTION
On clusters which have ceph configured to provide pvcs, this will prevent the prometheus tsdb from growing unbounded in the ephemeral disk space of the node on which the sts is scheduled.