### PR TITLE
(fleet/grafana) Add opensearch logging datasource to aggregator Grafana

### DIFF
--- a/fleet/lib/kube-prometheus-stack-pre/externalsecret-grafana-opensearch.yaml
+++ b/fleet/lib/kube-prometheus-stack-pre/externalsecret-grafana-opensearch.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-opensearch-credentials
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  data:
+    - secretKey: OS_LOGGING_USERNAME
+      remoteRef:
+        key: &item opensearch-grafana-user
+        property: username
+    - secretKey: OS_LOGGING_PASSWORD
+      remoteRef:
+        key: *item
+        property: password

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -178,7 +178,7 @@ grafana:
           uid: os-logs-kube
           basicAuth: true
           basicAuthUser: $OS_LOGGING_USERNAME
-          url: https://logging.logging:9200/
+          url: https://opensearch.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org
           access: proxy
           jsonData:
             database: logs-kube*
@@ -187,9 +187,8 @@ grafana:
             pplEnabled: true
             timeField: "@timetamp"
             logLevelField: ""
-            logMessageField: ""
+            logMessageField: log
             maxConcurrentShardRequests: 5
-            serverless: false
           secureJsonData:
             basicAuthPassword: $OS_LOGGING_PASSWORD
         - name: logs-hosts
@@ -197,7 +196,7 @@ grafana:
           uid: os-logs-hosts
           basicAuth: true
           basicAuthUser: $OS_LOGGING_USERNAME
-          url: https://logging.logging:9200/
+          url: https://opensearch.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org
           access: proxy
           jsonData:
             database: logs-hosts*
@@ -206,9 +205,8 @@ grafana:
             pplEnabled: true
             timeField: "@timetamp"
             logLevelField: ""
-            logMessageField: ""
+            logMessageField: message
             maxConcurrentShardRequests: 5
-            serverless: false
           secureJsonData:
             basicAuthPassword: $OS_LOGGING_PASSWORD
         - name: logs-firewall
@@ -216,7 +214,7 @@ grafana:
           uid: os-logs-firewall
           basicAuth: true
           basicAuthUser: $OS_LOGGING_USERNAME
-          url: https://logging.logging:9200/
+          url: https://opensearch.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org
           access: proxy
           jsonData:
             database: logs-firewall*
@@ -225,9 +223,8 @@ grafana:
             pplEnabled: true
             timeField: "@timetamp"
             logLevelField: ""
-            logMessageField: ""
+            logMessageField: message
             maxConcurrentShardRequests: 5
-            serverless: false
           secureJsonData:
             basicAuthPassword: $OS_LOGGING_PASSWORD
         - name: logs-network
@@ -235,7 +232,7 @@ grafana:
           uid: os-logs-network
           basicAuth: true
           basicAuthUser: $OS_LOGGING_USERNAME
-          url: https://logging.logging:9200/
+          url: https://opensearch.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org
           access: proxy
           jsonData:
             database: logs-network*
@@ -244,9 +241,8 @@ grafana:
             pplEnabled: true
             timeField: "@timetamp"
             logLevelField: ""
-            logMessageField: ""
+            logMessageField: message
             maxConcurrentShardRequests: 5
-            serverless: false
           secureJsonData:
             basicAuthPassword: $OS_LOGGING_PASSWORD
   envFromSecrets:

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -142,6 +142,8 @@ grafana:
       mountPath: /etc/secrets/keycloak-credentials
       secretName: grafana-keycloak-credentials
       readOnly: true
+  plugins:
+    - grafana-opensearch-datasource
   datasources:
     datasource.yaml:
       apiVersion: 1
@@ -171,3 +173,81 @@ grafana:
           jsonData:
             handleGrafanaManagedAlerts: false
             implementation: prometheus
+        - name: logs-kube
+          type: grafana-opensearch-datasource
+          uid: os-logs-kube
+          basicAuth: true
+          basicAuthUser: $OS_LOGGING_USERNAME
+          url: https://logging.logging:9200/
+          access: proxy
+          jsonData:
+            database: logs-kube*
+            flavour: opensearch
+            version: 2.11.0
+            pplEnabled: true
+            timeField: "@timetamp"
+            logLevelField: ""
+            logMessageField: ""
+            maxConcurrentShardRequests: 5
+            serverless: false
+          secureJsonData:
+            basicAuthPassword: $OS_LOGGING_PASSWORD
+        - name: logs-hosts
+          type: grafana-opensearch-datasource
+          uid: os-logs-hosts
+          basicAuth: true
+          basicAuthUser: $OS_LOGGING_USERNAME
+          url: https://logging.logging:9200/
+          access: proxy
+          jsonData:
+            database: logs-hosts*
+            flavour: opensearch
+            version: 2.11.0
+            pplEnabled: true
+            timeField: "@timetamp"
+            logLevelField: ""
+            logMessageField: ""
+            maxConcurrentShardRequests: 5
+            serverless: false
+          secureJsonData:
+            basicAuthPassword: $OS_LOGGING_PASSWORD
+        - name: logs-firewall
+          type: grafana-opensearch-datasource
+          uid: os-logs-firewall
+          basicAuth: true
+          basicAuthUser: $OS_LOGGING_USERNAME
+          url: https://logging.logging:9200/
+          access: proxy
+          jsonData:
+            database: logs-firewall*
+            flavour: opensearch
+            version: 2.11.0
+            pplEnabled: true
+            timeField: "@timetamp"
+            logLevelField: ""
+            logMessageField: ""
+            maxConcurrentShardRequests: 5
+            serverless: false
+          secureJsonData:
+            basicAuthPassword: $OS_LOGGING_PASSWORD
+        - name: logs-network
+          type: grafana-opensearch-datasource
+          uid: os-logs-network
+          basicAuth: true
+          basicAuthUser: $OS_LOGGING_USERNAME
+          url: https://logging.logging:9200/
+          access: proxy
+          jsonData:
+            database: logs-network*
+            flavour: opensearch
+            version: 2.11.0
+            pplEnabled: true
+            timeField: "@timetamp"
+            logLevelField: ""
+            logMessageField: ""
+            maxConcurrentShardRequests: 5
+            serverless: false
+          secureJsonData:
+            basicAuthPassword: $OS_LOGGING_PASSWORD
+  envFromSecrets:
+    - name: grafana-opensearch-credentials

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -189,6 +189,7 @@ grafana:
             logLevelField: ""
             logMessageField: log
             maxConcurrentShardRequests: 5
+            oauthPassThru: true
           secureJsonData:
             basicAuthPassword: $OS_LOGGING_PASSWORD
         - name: logs-hosts
@@ -207,6 +208,7 @@ grafana:
             logLevelField: ""
             logMessageField: message
             maxConcurrentShardRequests: 5
+            oauthPassThru: true
           secureJsonData:
             basicAuthPassword: $OS_LOGGING_PASSWORD
         - name: logs-firewall
@@ -225,6 +227,7 @@ grafana:
             logLevelField: ""
             logMessageField: message
             maxConcurrentShardRequests: 5
+            oauthPassThru: true
           secureJsonData:
             basicAuthPassword: $OS_LOGGING_PASSWORD
         - name: logs-network
@@ -243,6 +246,7 @@ grafana:
             logLevelField: ""
             logMessageField: message
             maxConcurrentShardRequests: 5
+            oauthPassThru: true
           secureJsonData:
             basicAuthPassword: $OS_LOGGING_PASSWORD
   envFromSecrets:

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -182,14 +182,14 @@ grafana:
           access: proxy
           jsonData:
             database: logs-kube*
-            flavour: opensearch
-            version: 2.11.0
-            pplEnabled: true
-            timeField: "@timetamp"
+            flavor: opensearch
             logLevelField: ""
             logMessageField: log
             maxConcurrentShardRequests: 5
             oauthPassThru: true
+            pplEnabled: true
+            timeField: "@timestamp"
+            version: 2.11.0
           secureJsonData:
             basicAuthPassword: $OS_LOGGING_PASSWORD
         - name: logs-hosts
@@ -201,14 +201,14 @@ grafana:
           access: proxy
           jsonData:
             database: logs-hosts*
-            flavour: opensearch
-            version: 2.11.0
-            pplEnabled: true
-            timeField: "@timetamp"
+            flavor: opensearch
             logLevelField: ""
             logMessageField: message
             maxConcurrentShardRequests: 5
             oauthPassThru: true
+            pplEnabled: true
+            timeField: "@timestamp"
+            version: 2.11.0
           secureJsonData:
             basicAuthPassword: $OS_LOGGING_PASSWORD
         - name: logs-firewall
@@ -220,14 +220,14 @@ grafana:
           access: proxy
           jsonData:
             database: logs-firewall*
-            flavour: opensearch
-            version: 2.11.0
-            pplEnabled: true
-            timeField: "@timetamp"
+            flavor: opensearch
             logLevelField: ""
             logMessageField: message
             maxConcurrentShardRequests: 5
             oauthPassThru: true
+            pplEnabled: true
+            timeField: "@timestamp"
+            version: 2.11.0
           secureJsonData:
             basicAuthPassword: $OS_LOGGING_PASSWORD
         - name: logs-network
@@ -239,14 +239,14 @@ grafana:
           access: proxy
           jsonData:
             database: logs-network*
-            flavour: opensearch
-            version: 2.11.0
-            pplEnabled: true
-            timeField: "@timetamp"
+            flavor: opensearch
             logLevelField: ""
             logMessageField: message
             maxConcurrentShardRequests: 5
             oauthPassThru: true
+            pplEnabled: true
+            timeField: "@timestamp"
+            version: 2.11.0
           secureJsonData:
             basicAuthPassword: $OS_LOGGING_PASSWORD
   envFromSecrets:


### PR DESCRIPTION
Splitting up https://github.com/lsst-it/k8s-cookbook/pull/346

This PR splits out the data source addition from https://github.com/lsst-it/k8s-cookbook/pull/346/commits into a smaller commit, making the merge easier on both sides.