### PR TITLE
(fleet/prom-stack) Prometheus stack config cleanup

### DIFF
--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -46,6 +46,27 @@ alertmanager:
       - secretName: tls-alertmanager-ingress
         hosts:
           - alertmanager.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org
+  config:
+    global:
+      resolve_timeout: 5m
+    inhibit_rules:
+      - source_matchers:
+          - alertname = "InfoInhibitor"
+        target_matchers:
+          - severity = "info"
+        equal: ["namespace"]
+      - source_matchers:
+          - severity = "critical"
+        target_matchers:
+          - severity =~ "info|warning"
+        equal: ["alertname"]
+      - source_matchers:
+          - severity = "warning"
+        target_matchers:
+          - severity = "info"
+        equal: ["alertname"]
+    templates:
+      - "/etc/alertmanager/configmaps/alertmanager-templates/*.tmpl"
 
 grafana:
   enabled: true

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -54,19 +54,19 @@ alertmanager:
           - alertname = "InfoInhibitor"
         target_matchers:
           - severity = "info"
-        equal: ["namespace"]
+        equal: [namespace]
       - source_matchers:
           - severity = "critical"
         target_matchers:
           - severity =~ "info|warning"
-        equal: ["alertname"]
+        equal: [alertname]
       - source_matchers:
           - severity = "warning"
         target_matchers:
           - severity = "info"
-        equal: ["alertname"]
+        equal: [alertname]
     templates:
-      - "/etc/alertmanager/configmaps/alertmanager-templates/*.tmpl"
+      - /etc/alertmanager/configmaps/alertmanager-templates/*.tmpl
 
 grafana:
   enabled: true

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -101,7 +101,7 @@ grafana:
       enabled: true
       group_attribute_path: groups
       login_attribute_path: preferred_username
-      name: keycloak.ls.lsst.org
+      name: $__file{/etc/secrets/keycloak-credentials/url}
       role_attribute_path: contains(groups[*], 'grafana-admin') && 'GrafanaAdmin' || contains(groups[*], 'grafana-admin') && 'Admin' || contains(groups[*], 'grafana-editor') && 'Editor' || 'Viewer'
       scopes: openid profile email groups roles offline_access
       token_url: https://keycloak.ls.lsst.org/realms/master/protocol/openid-connect/token

--- a/fleet/lib/kube-prometheus-stack/overlays/ayekan/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/overlays/ayekan/values.yaml
@@ -179,6 +179,8 @@ alertmanager:
     secrets:
       - lsst-webhooks
   config:
+    global:
+      slack_api_url_file: /etc/alertmanager/secrets/lsst-webhooks/slack-test
     route:
       group_by: [alertname, namespace, site]
       group_wait: 30s

--- a/fleet/lib/kube-prometheus-stack/overlays/ayekan/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/overlays/ayekan/values.yaml
@@ -212,14 +212,6 @@ alertmanager:
               group_by: ["instance"]
               matchers:
                 - alertname =~ "Network.*"
-        - receiver: slack-test
-          matchers:
-            - alertname =~ "Ceph.*"
-            - severity =~ "warning|critical"
-        - receiver: squadcast-test
-          matchers:
-            - alertname =~ "Ceph.*"
-            - severity = "critical"
         # Below is an example for the namespace based alert routing.
         # This will send alerts from a namespace to the namespace specific team
         # on slack

--- a/fleet/lib/kube-prometheus-stack/overlays/ayekan/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/overlays/ayekan/values.yaml
@@ -198,7 +198,7 @@ alertmanager:
           matchers:
             - receivers =~ ".*,squadcast,.*"
           continue: true
-        - receiver: "slack-test"
+        - receiver: slack-test
           matchers:
             - receivers =~ ".*,slack,.*"
           continue: true
@@ -207,11 +207,11 @@ alertmanager:
               matchers:
                 - alertname =~ "Kube.*"
             - receiver: slack-node-test
-              group_by: ["instance"]
+              group_by: [instance]
               matchers:
                 - alertname =~ "Node.*"
             - receiver: slack-network-test
-              group_by: ["instance"]
+              group_by: [instance]
               matchers:
                 - alertname =~ "Network.*"
         # Below is an example for the namespace based alert routing.
@@ -258,6 +258,6 @@ alertmanager:
       - name: squadcast-test
         webhook_configs:
           - url_file: /etc/alertmanager/secrets/lsst-webhooks/squadcast-example
-      - name: "slack-rook-ceph-team"
-      - name: "slack-metallb-team"
-      - name: "slack-monitoring-team"
+      - name: slack-rook-ceph-team
+      - name: slack-metallb-team
+      - name: slack-monitoring-team

--- a/fleet/lib/kube-prometheus-stack/overlays/ayekan/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/overlays/ayekan/values.yaml
@@ -179,15 +179,12 @@ alertmanager:
     secrets:
       - lsst-webhooks
   config:
-    global:
-      resolve_timeout: 5m
-      slack_api_url_file: /etc/alertmanager/secrets/lsst-webhooks/slack-test
     route:
       group_by: [alertname, namespace, site]
       group_wait: 30s
       group_interval: 5m
       repeat_interval: 24h
-      receiver: slack-test
+      receiver: "null"
       routes:
         - receiver: "null"
           matchers:
@@ -199,17 +196,42 @@ alertmanager:
           matchers:
             - receivers =~ ".*,squadcast,.*"
           continue: true
-        - receiver: slack-kube-test
+        - receiver: "slack-test"
           matchers:
-            - alertname =~ "Kube.*"
-        - receiver: slack-node-test
-          group_by: [instance]
+            - receivers =~ ".*,slack,.*"
+          continue: true
+          routes:
+            - receiver: slack-kube-test
+              matchers:
+                - alertname =~ "Kube.*"
+            - receiver: slack-node-test
+              group_by: ["instance"]
+              matchers:
+                - alertname =~ "Node.*"
+            - receiver: slack-network-test
+              group_by: ["instance"]
+              matchers:
+                - alertname =~ "Network.*"
+        - receiver: slack-test
           matchers:
-            - alertname =~ "Node.*"
-        - receiver: slack-network-test
-          group_by: [instance]
+            - alertname =~ "Ceph.*"
+            - severity =~ "warning|critical"
+        - receiver: squadcast-test
           matchers:
-            - alertname =~ "Network.*"
+            - alertname =~ "Ceph.*"
+            - severity = "critical"
+        # Below is an example for the namespace based alert routing.
+        # This will send alerts from a namespace to the namespace specific team
+        # on slack
+        # - receiver: slack-rook-ceph-team
+        #   matchers:
+        #     - namespace = "rook-ceph"
+        # Below is an example for the group based alert routing.
+        # This will send alerts with a specifc group in the receiver list to the
+        # alert channel.
+        # - receiver: email-group
+        #   matchers:
+        #     - receivers =~ ".*,group,.*"
     receivers:
       - name: "null"
       - name: watchdog
@@ -242,21 +264,6 @@ alertmanager:
       - name: squadcast-test
         webhook_configs:
           - url_file: /etc/alertmanager/secrets/lsst-webhooks/squadcast-example
-    inhibit_rules:
-      - source_matchers:
-          - alertname = "InfoInhibitor"
-        target_matchers:
-          - severity = "info"
-        equal: [namespace]
-      - source_matchers:
-          - severity = "critical"
-        target_matchers:
-          - severity =~ "info|warning"
-        equal: [alertname]
-      - source_matchers:
-          - severity = "warning"
-        target_matchers:
-          - severity = "info"
-        equal: [alertname]
-    templates:
-      - /etc/alertmanager/configmaps/alertmanager-templates/*.tmpl
+      - name: "slack-rook-ceph-team"
+      - name: "slack-metallb-team"
+      - name: "slack-monitoring-team"

--- a/fleet/lib/kube-prometheus-stack/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/values.yaml
@@ -7,8 +7,6 @@ defaultRules:
   create: true
   labels:
     lsst.io/rule: "true"
-  additionalRuleLabels:
-    receivers: ",squadcast,"
   disabled:
     TargetDown: true
 

--- a/fleet/lib/kube-prometheus-stack/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/values.yaml
@@ -121,6 +121,10 @@ coreDns:
   serviceMonitor:
     additionalLabels:
       lsst.io/monitor: "true"
+kubeDns:
+  serviceMonitor:
+    additionalLabels:
+      lsst.io/monitor: "true"
 kubeEtcd:
   serviceMonitor:
     additionalLabels:

--- a/fleet/lib/kube-prometheus-stack/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/values.yaml
@@ -119,10 +119,6 @@ coreDns:
   serviceMonitor:
     additionalLabels:
       lsst.io/monitor: "true"
-kubeDns:
-  serviceMonitor:
-    additionalLabels:
-      lsst.io/monitor: "true"
 kubeEtcd:
   serviceMonitor:
     additionalLabels:


### PR DESCRIPTION
The prometheus stack config drift has gotten a bit too large. Use this task to clean up smaller parts that do not belong into a larger task.

Part of splitting https://github.com/lsst-it/k8s-cookbook/pull/346 into smaller chunks.