### PR TITLE
(fleet/*) prune unnecessary bundle deps

### DIFF
--- a/fleet/lib/blackbox-exporter/fleet.yaml
+++ b/fleet/lib/blackbox-exporter/fleet.yaml
@@ -20,7 +20,3 @@ dependsOn:
   - selector:
       matchLabels:
         bundle: cert-manager-conf
-  # ingress-nginx isn't fleet deployed on pillan
-  #- selector:
-  #   matchLabels:
-  #      bundle: ingress-nginx

--- a/fleet/lib/blackbox-exporter/fleet.yaml
+++ b/fleet/lib/blackbox-exporter/fleet.yaml
@@ -17,6 +17,3 @@ dependsOn:
   - selector:
       matchLabels:
         bundle: prometheus-operator-crds
-  - selector:
-      matchLabels:
-        bundle: cert-manager-conf

--- a/fleet/lib/cert-manager-conf/fleet.yaml
+++ b/fleet/lib/cert-manager-conf/fleet.yaml
@@ -16,7 +16,7 @@ dependsOn:
   #      bundle: cert-manager
   - selector:
       matchLabels:
-        bundle: external-secrets-conf
+        bundle: external-secrets
 targetCustomizations:
   - name: konkong
     clusterName: konkong

--- a/fleet/lib/cnpg-cluster/fleet.yaml
+++ b/fleet/lib/cnpg-cluster/fleet.yaml
@@ -13,7 +13,7 @@ dependsOn:
         bundle: cnpg-system
   - selector:
       matchLabels:
-        bundle: external-secrets-conf
+        bundle: external-secrets
   - selector:
       matchLabels:
         bundle: prometheus-operator-crds

--- a/fleet/lib/fluentbit/fleet.yaml
+++ b/fleet/lib/fluentbit/fleet.yaml
@@ -16,4 +16,4 @@ dependsOn:
         bundle: cert-manager-conf
   - selector:
       matchLabels:
-        bundle: external-secrets-conf
+        bundle: external-secrets

--- a/fleet/lib/fluentbit/fleet.yaml
+++ b/fleet/lib/fluentbit/fleet.yaml
@@ -13,7 +13,7 @@ helm:
 dependsOn:
   - selector:
       matchLabels:
-        bundle: cert-manager-conf
+        bundle: cert-manager-crds
   - selector:
       matchLabels:
         bundle: external-secrets

--- a/fleet/lib/ingress-nginx-lhn/fleet.yaml
+++ b/fleet/lib/ingress-nginx-lhn/fleet.yaml
@@ -29,10 +29,6 @@ helm:
     rbac:
       create: true
   waitForJobs: true
-dependsOn:
-  - selector:
-      matchLabels:
-        bundle: metallb
 targetCustomizations:
   - name: default
     clusterSelector:

--- a/fleet/lib/ingress-nginx/fleet.yaml
+++ b/fleet/lib/ingress-nginx/fleet.yaml
@@ -62,10 +62,6 @@ helm:
     rbac:
       create: true
   waitForJobs: true
-dependsOn:
-  - selector:
-      matchLabels:
-        bundle: metallb
 targetCustomizations:
   - name: default
     clusterSelector:

--- a/fleet/lib/kube-prometheus-stack-pre/fleet.yaml
+++ b/fleet/lib/kube-prometheus-stack-pre/fleet.yaml
@@ -11,7 +11,7 @@ helm:
 dependsOn:
   - selector:
       matchLabels:
-        bundle: external-secrets-conf
+        bundle: external-secrets
 targetCustomizations:
   - name: ayekan
     clusterName: ayekan

--- a/fleet/lib/metallb-demo/fleet.yaml
+++ b/fleet/lib/metallb-demo/fleet.yaml
@@ -6,10 +6,6 @@ helm:
   releaseName: *name
   takeOwnership: true
   force: true
-dependsOn:
-  - selector:
-      matchLabels:
-        bundle: metallb-conf
 targetCustomizations:
   - name: ruka
     clusterName: ruka

--- a/fleet/lib/mimir-pre/fleet.yaml
+++ b/fleet/lib/mimir-pre/fleet.yaml
@@ -12,7 +12,7 @@ helm:
 dependsOn:
   - selector:
       matchLabels:
-        bundle: external-secrets-conf
+        bundle: external-secrets
 targetCustomizations:
   - name: pillan
     clusterName: pillan

--- a/fleet/lib/multus-demo/fleet.yaml
+++ b/fleet/lib/multus-demo/fleet.yaml
@@ -6,10 +6,6 @@ helm:
   releaseName: *name
   takeOwnership: true
   waitForJobs: true
-dependsOn:
-  - selector:
-      matchLabels:
-        bundle: multus-conf
 targetCustomizations:
   - name: kueyen
     clusterName: kueyen

--- a/fleet/lib/opensearch-logging/fleet.yaml
+++ b/fleet/lib/opensearch-logging/fleet.yaml
@@ -16,7 +16,7 @@ dependsOn:
         bundle: opensearch-operator
   - selector:
       matchLabels:
-        bundle: cert-manager-conf
+        bundle: cert-manager-crds
   - selector:
       matchLabels:
         bundle: external-secrets

--- a/fleet/lib/opensearch-logging/fleet.yaml
+++ b/fleet/lib/opensearch-logging/fleet.yaml
@@ -19,7 +19,7 @@ dependsOn:
         bundle: cert-manager-conf
   - selector:
       matchLabels:
-        bundle: external-secrets-conf
+        bundle: external-secrets
 targetCustomizations:
   # first match is used
   - name: ayekan

--- a/fleet/lib/opensearch-logging/fleet.yaml
+++ b/fleet/lib/opensearch-logging/fleet.yaml
@@ -20,9 +20,6 @@ dependsOn:
   - selector:
       matchLabels:
         bundle: external-secrets-conf
-  - selector:
-      matchLabels:
-        bundle: ingress-nginx
 targetCustomizations:
   # first match is used
   - name: ayekan

--- a/fleet/lib/rook-ceph-cluster/fleet.yaml
+++ b/fleet/lib/rook-ceph-cluster/fleet.yaml
@@ -23,10 +23,6 @@ dependsOn:
   - selector:
       matchLabels:
         bundle: cert-manager-conf
-  # ingress-nginx isn't fleet deployed on pillan
-  #- selector:
-  #   matchLabels:
-  #      bundle: ingress-nginx
 diff:
   comparePatches:
     - apiVersion: ceph.rook.io/v1

--- a/fleet/lib/rook-ceph-cluster/fleet.yaml
+++ b/fleet/lib/rook-ceph-cluster/fleet.yaml
@@ -20,9 +20,6 @@ dependsOn:
   - selector:
       matchLabels:
         bundle: prometheus-operator-crds
-  - selector:
-      matchLabels:
-        bundle: cert-manager-conf
 diff:
   comparePatches:
     - apiVersion: ceph.rook.io/v1

--- a/fleet/lib/rook-ceph-conf/fleet.yaml
+++ b/fleet/lib/rook-ceph-conf/fleet.yaml
@@ -11,7 +11,7 @@ helm:
 dependsOn:
   - selector:
       matchLabels:
-        bundle: rook-ceph-cluster
+        bundle: rook-ceph
 diff:
   comparePatches:
     - apiVersion: ceph.rook.io/v1

--- a/fleet/lib/rook-ceph-demo/fleet.yaml
+++ b/fleet/lib/rook-ceph-demo/fleet.yaml
@@ -10,7 +10,7 @@ helm:
 dependsOn:
   - selector:
       matchLabels:
-        bundle: rook-ceph-conf
+        bundle: rook-ceph
 targetCustomizations:
   - name: kueyen
     clusterName: kueyen

--- a/fleet/lib/snmp-exporter-pre/fleet.yaml
+++ b/fleet/lib/snmp-exporter-pre/fleet.yaml
@@ -18,7 +18,7 @@ helm:
 dependsOn:
   - selector:
       matchLabels:
-        bundle: external-secrets-conf
+        bundle: external-secrets
 targetCustomizations:
   - name: pillan
     clusterName: pillan

--- a/fleet/lib/snmp-exporter/fleet.yaml
+++ b/fleet/lib/snmp-exporter/fleet.yaml
@@ -20,6 +20,3 @@ dependsOn:
   - selector:
       matchLabels:
         bundle: prometheus-operator-crds
-  - selector:
-      matchLabels:
-        bundle: cert-manager-conf

--- a/fleet/lib/snmp-exporter/fleet.yaml
+++ b/fleet/lib/snmp-exporter/fleet.yaml
@@ -23,7 +23,3 @@ dependsOn:
   - selector:
       matchLabels:
         bundle: cert-manager-conf
-  # ingress-nginx isn't fleet deployed on pillan
-  #- selector:
-  #   matchLabels:
-  #      bundle: ingress-nginx

--- a/fleet/lib/velero-conf/fleet.yaml
+++ b/fleet/lib/velero-conf/fleet.yaml
@@ -10,7 +10,7 @@ helm:
 dependsOn:
   - selector:
       matchLabels:
-        bundle: external-secrets-conf
+        bundle: external-secrets
 targetCustomizations:
   - name: dev
     clusterSelector:


### PR DESCRIPTION
Reducing the complexity of the dep graph will speed up convergence time.