### PR TITLE
(fleet/prometheus-alerts) fix HostDown rule

### DIFF
--- a/fleet/lib/prometheus-alerts/rules/prometheusrule-net.yaml
+++ b/fleet/lib/prometheus-alerts/rules/prometheusrule-net.yaml
@@ -1,4 +1,3 @@
----
 groups:
   - name: host.rules
     rules:


### PR DESCRIPTION
The `---` yaml header was breaking the helm templating of the `prometheusrule` CR.