### PR TITLE
(fleet/kube-prometheus-stack) fix prom pvc filling up

### DIFF
--- a/fleet/lib/kube-prometheus-stack/pvc/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/pvc/values.yaml
@@ -8,4 +8,4 @@ prometheus:
           storageClassName: rook-ceph-block
           resources:
             requests:
-              storage: 50Gi
+              storage: 100Gi

--- a/fleet/lib/kube-prometheus-stack/pvc/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/pvc/values.yaml
@@ -1,6 +1,7 @@
 ---
 prometheus:
   prometheusSpec:
+    retentionSize: 75GB
     storageSpec:
       volumeClaimTemplate:
         spec:


### PR DESCRIPTION
On antu, a 50GiB PVC was not large enough for prom default 15 day retention period.  To prevent this from happening we are enlarging the PVC so that it should accommodate ~1weeks worth of data even on an aggegration cluster and switch from time to a size based retention window.