### PR TITLE
(fleet/kube-prometheus-stack) disable prom pvc on chonchon

### DIFF
--- a/fleet/lib/kube-prometheus-stack/fleet.yaml
+++ b/fleet/lib/kube-prometheus-stack/fleet.yaml
@@ -85,6 +85,7 @@ targetCustomizations:
         - key: management.cattle.io/cluster-display-name
           operator: In
           values:
+            - chonchon
             - konkong
             - local
     helm:


### PR DESCRIPTION
As chonchon does not have ceph rbd deployed.