### PR TITLE
(fleet/kube-prometheus-stack) set kube-state-metrics limit to 384Mi

### DIFF
--- a/fleet/lib/kube-prometheus-stack/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/values.yaml
@@ -139,10 +139,10 @@ kube-state-metrics:
   resources:
     limits:
       cpu: 100m
-      memory: 256Mi
+      memory: 384Mi
     requests:
       cpu: 10m
-      memory: 256Mi
+      memory: 384Mi
   prometheus:
     monitor:
       additionalLabels:


### PR DESCRIPTION
On yagan, the kube-state-metrics pod is beeing OOMKilled.