### PR TITLE
(fleet/cnpg-cluster) more resource to yagan deploy

### DIFF
--- a/fleet/lib/cnpg-cluster/overlays/yagan/cluster-cnpg-cluster.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/yagan/cluster-cnpg-cluster.yaml
@@ -38,8 +38,8 @@ spec:
 
   resources:
     limits:
-      cpu: "1"
-      memory: 1Gi
+      cpu: "2"
+      memory: 4Gi
     requests:
-      cpu: 500m
-      memory: 1Gi
+      cpu: "1"
+      memory: 2Gi


### PR DESCRIPTION
cnpg resources were a bit tight on the summit.
current: 750m~ CPU / 914 MEM
