### PR TITLE
(site/cp) bump rke to v1.28.10-rancher1-1

### DIFF
--- a/chonchon/rke/cluster.yml
+++ b/chonchon/rke/cluster.yml
@@ -37,6 +37,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.28.9-rancher1-1
+kubernetes_version: v1.28.10-rancher1-1
 ingress:
   provider: none

--- a/lukay/rke/cluster.yml
+++ b/lukay/rke/cluster.yml
@@ -46,6 +46,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.28.9-rancher1-1
+kubernetes_version: v1.28.10-rancher1-1
 ingress:
   provider: none

--- a/rancher.cp/rke/cluster.yml
+++ b/rancher.cp/rke/cluster.yml
@@ -31,6 +31,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.28.9-rancher1-1
+kubernetes_version: v1.28.10-rancher1-1
 ingress:
   provider: none

--- a/yagan/rke/cluster.yml
+++ b/yagan/rke/cluster.yml
@@ -160,6 +160,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.28.9-rancher1-1
+kubernetes_version: v1.28.10-rancher1-1
 ingress:
   provider: none

--- a/yepun/rke/cluster.yml
+++ b/yepun/rke/cluster.yml
@@ -55,6 +55,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.28.9-rancher1-1
+kubernetes_version: v1.28.10-rancher1-1
 ingress:
   provider: none


### PR DESCRIPTION
bumping k8s version to 1.28.10 on all CP clusters.