### PR TITLE
(fleet/local-static-provisioner) add deployment on kueyen

### DIFF
--- a/fleet/lib/local-static-provisioner/fleet.yaml
+++ b/fleet/lib/local-static-provisioner/fleet.yaml
@@ -1,0 +1,12 @@
+---
+defaultNamespace: &name local-static-provisioner
+labels:
+  bundle: *name
+helm:
+  chart: *name
+  releaseName: *name
+  repo: https://kubernetes-sigs.github.io/sig-storage-local-static-provisioner
+  timeoutSeconds: 120
+  waitForJobs: true
+  valuesFiles:
+    - values.yaml

--- a/fleet/lib/local-static-provisioner/values.yaml
+++ b/fleet/lib/local-static-provisioner/values.yaml
@@ -1,0 +1,28 @@
+classes:
+  - name: localdrive
+    hostDir: /drives
+    blockCleanerCommand:
+      - /scripts/shred.sh
+      - "2"
+    volumeMode: Filesystem
+    fsType: xfs
+    namePattern: "*"
+    storageClass: true
+    isDefaultClass: false
+
+nodeSelector:
+  local-storage: "true"
+
+resources:
+  limits:
+    memory: 512Mi
+    cpu: 500m
+  requests:
+    memory: 256Mi
+    cpu: 100m
+
+serviceMonitor:
+  enabled: true
+  interval: 10s
+  additionalLabels:
+    lsst.io/monitor: "true"

--- a/fleet/s/dev/c/kueyen/local-static-provisioner
+++ b/fleet/s/dev/c/kueyen/local-static-provisioner
@@ -1,0 +1,1 @@
+../../../../lib/local-static-provisioner

--- a/kueyen/rke/cluster.yml
+++ b/kueyen/rke/cluster.yml
@@ -9,6 +9,7 @@ nodes:
   - etcd
   labels:
     role: storage-node
+    local-storage: "true"
 - address: kueyen02.dev.lsst.org
   hostname_override: kueyen02
   user: rke
@@ -32,6 +33,8 @@ services:
     extra_args:
       node-status-max-images: "-1"
       max-pods: 250
+    extra_binds:
+    - /drives/localdrive:/drives/localdrive
 network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa


### PR DESCRIPTION
when using a container version of kubelet, we need to add that bind to get  permissions to access that path.
the labels are for nodeSelector.