### PR TITLE
(fleet/local-static-provisioner) add deployment on manke

### DIFF
--- a/fleet/s/ls/c/manke/local-static-provisioner
+++ b/fleet/s/ls/c/manke/local-static-provisioner
@@ -1,0 +1,1 @@
+../../../../lib/local-static-provisioner

--- a/manke/rke/cluster.yml
+++ b/manke/rke/cluster.yml
@@ -68,6 +68,7 @@ nodes:
   - worker
   labels:
     role: storage-node
+    local-storage: "true"
 - address: manke09.ls.lsst.org
   hostname_override: manke09
   user: rke
@@ -75,6 +76,7 @@ nodes:
   - worker
   labels:
     role: storage-node
+    local-storage: "true"
 - address: manke10.ls.lsst.org
   hostname_override: manke10
   user: rke
@@ -82,10 +84,13 @@ nodes:
   - worker
   labels:
     role: storage-node
+    local-storage: "true"
 services:
   kubelet:
     extra_args:
       node-status-max-images: "-1"
+    extra_binds:
+    - /drives/localdrive:/drives/localdrive
 network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa


### PR DESCRIPTION
need to add the local provisioner to Manke to mount Kafka there on Manke08, 09, and 10.