### PR TITLE
(fleet/mimir) set gw client_max_body_size via new chart value

### DIFF
--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -189,8 +189,8 @@ gateway:
   replicas: 2
   nginx:
     config:
+      clientMaxBodySize: 10m
       serverSnippet: |
-        client_max_body_size    10m;
         client_body_buffer_size 10m;
   ingress:
     enabled: true


### PR DESCRIPTION
This commit adds a gateway.nginx.config.clientMaxBodySize value which replaces the need for setting the client_max_body_size nginx parameter via a custom config snippet:

https://github.com/grafana/mimir/commit/ef00f588e837ec9c28c740afebecaafba5f9d1e1