### PR TITLE
(fleet/local-static-provisioner) add label on yagan17

### DIFF
--- a/yagan/rke/cluster.yml
+++ b/yagan/rke/cluster.yml
@@ -131,6 +131,7 @@ nodes:
   - worker
   labels:
     role: storage-node
+    local-storage: "true"
 - address: yagan18.cp.lsst.org
   hostname_override: yagan18
   user: rke


### PR DESCRIPTION
we added a disk to yagan17 to hold the influxDB deployment on a separate node.