### PR TITLE
(fleet/rook-ceph-conf) add rsphome export for manke

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/manke/templates/cephnfs-rsphome.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/manke/templates/cephnfs-rsphome.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephFilesystem
+metadata:
+  name: rsphome
+  namespace: rook-ceph
+spec:
+  metadataPool:
+    failureDomain: host
+    replicated:
+      size: 3
+    quotas:
+      maxSize: 10Gi
+  dataPools:
+    - name: default
+      failureDomain: host
+      replicated:
+        size: 3
+      quotas:
+        maxSize: 250Gi
+    - name: ec
+      failureDomain: host
+      erasureCoded:
+        dataChunks: 6
+        codingChunks: 3
+      quotas:
+        maxSize: 250Gi
+  metadataServer:
+    activeCount: 3
+    activeStandby: true
+    resources:
+      limits:
+        cpu: "4"
+        memory: 4Gi
+      requests:
+        cpu: "4"
+        memory: 4Gi
+  preserveFilesystemOnDelete: false
+---
+apiVersion: ceph.rook.io/v1
+kind: CephNFS
+metadata:
+  name: rsphome
+  namespace: rook-ceph
+spec:
+  rados:
+    pool: rsphome-data0
+    # RADOS namespace where NFS client recovery data is stored in the pool.
+    namespace: nfs-ns
+  server:
+    active: 1
+    resources:
+      limits:
+        cpu: "3"
+        memory: 8Gi
+      requests:
+        cpu: "3"
+        memory: 8Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: rook-ceph-nfs
+    ceph_daemon_type: nfs
+    ceph_nfs: rsphome
+    instance: a
+    rook_cluster: rook-ceph
+  name: rook-ceph-nfs-rsphome
+  namespace: rook-ceph
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 139.229.151.163
+spec:
+  ports:
+    - name: nfs
+      port: 2049
+      protocol: TCP
+      targetPort: 2049
+  selector:
+    app: rook-ceph-nfs
+    ceph_daemon_type: nfs
+    ceph_nfs: rsphome
+    instance: a
+    rook_cluster: rook-ceph
+  type: LoadBalancer

--- a/fleet/lib/rook-ceph-conf/charts/manke/templates/cm-cephcli.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/manke/templates/cm-cephcli.yaml
@@ -38,6 +38,10 @@ data:
     ceph nfs export rm comcam /comcam
     ceph nfs export create cephfs comcam /comcam comcam
 
+    waitfornfs rsphome
+    ceph nfs export rm rsphome /rsphome
+    ceph nfs export create cephfs rsphome /rsphome rsphome
+
     ceph mgr module enable rook
     ceph orch set backend rook
     ceph device monitoring on


### PR DESCRIPTION
This ticket was developed on another branch that never got merged(pre-fleet), so I noticed this while cleaning old branches.
this is the same NFS but for Fleet.

need help checking this line `ceph nfs export create cephfs rsphome /rsphome rsphome`
not sure if it is the correct creation path (if it matches the current one)
(I think it is good, but it would be great if someone else could check this, as this is already in production)

