### PR TITLE
Revert "Merge pull request #544 from lsst-it/renovate/kyverno-3.x"

### DIFF
--- a/fleet/lib/kyverno/fleet.yaml
+++ b/fleet/lib/kyverno/fleet.yaml
@@ -9,7 +9,7 @@ helm:
   chart: *name
   releaseName: *name
   repo: https://kyverno.github.io/kyverno/
-  version: 3.2.6
+  version: 3.2.5
   timeoutSeconds: 300
   waitForJobs: true
   values:


### PR DESCRIPTION
Revert https://github.com/lsst-it/k8s-cookbook/pull/544 as it broke the `kyverno-reports-controller`. E.g.:

```
$ k logs kyverno-reports-controller-9d8b78cd4-45t5p
flag provided but not defined: -maxAdmissionReports
Usage of /ko-app/reports-controller:
  -add_dir_header
    	If true, adds the file directory to the header of the log messages
  -admissionReports
...
```