### PR TITLE
(fleet/rook) set limits on auxtel mds to 16Gi on Yagan

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/yagan/templates/cephnfs-auxtel.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/yagan/templates/cephnfs-auxtel.yaml
@@ -44,10 +44,10 @@ spec:
     resources:
       limits:
         cpu: "3"
-        memory: 8Gi
+        memory: 16Gi
       requests:
         cpu: "3"
-        memory: 8Gi
+        memory: 16Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
we saw the OOM Killer do his thing on the `nfs-auxtel-a` pod causing it to restart.