### PR TITLE
(fleet/cnpg-cluster) PVC bump to 10Gi on yagan

### DIFF
--- a/fleet/lib/cnpg-cluster/overlays/yagan/cluster-cnpg-cluster.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/yagan/cluster-cnpg-cluster.yaml
@@ -31,7 +31,7 @@ spec:
 # Resources and Storage Needs to be Adjust!
 
   storage:
-    size: 5Gi
+    size: 10Gi
 
   monitoring:
     enablePodMonitor: true


### PR DESCRIPTION
Butler database on `cloudnativePG` on `Yagan` filled the PVC, so it was increased from `5Gi` to `10Gi`