### PR TITLE
(fleet/*) set helm.timeoutSeconds for all bundles

### DIFF
--- a/fleet/lib/alertbit/fleet.yaml
+++ b/fleet/lib/alertbit/fleet.yaml
@@ -10,4 +10,5 @@ helm:
   version: v0.1.0
   valuesFiles:
     - values.yaml
+  timeoutSeconds: 60
   waitForJobs: true

--- a/fleet/lib/alertmanager2kafka/fleet.yaml
+++ b/fleet/lib/alertmanager2kafka/fleet.yaml
@@ -10,5 +10,5 @@ helm:
   version: v0.1.2
   valuesFiles:
     - values.yaml
-  waitForJobs: true
   timeoutSeconds: 90
+  waitForJobs: true

--- a/fleet/lib/cert-manager-conf/fleet.yaml
+++ b/fleet/lib/cert-manager-conf/fleet.yaml
@@ -8,6 +8,7 @@ helm:
   releaseName: *name
   takeOwnership: true
   force: true
+  timeoutSeconds: 60
   waitForJobs: true
 dependsOn:
   # on pillan, fleet does not deploy cert-manager

--- a/fleet/lib/cert-manager-crds/fleet.yaml
+++ b/fleet/lib/cert-manager-crds/fleet.yaml
@@ -10,4 +10,5 @@ helm:
   releaseName: *name
   takeOwnership: true
   force: true
+  timeoutSeconds: 60
   waitForJobs: true

--- a/fleet/lib/cnpg-cluster/fleet.yaml
+++ b/fleet/lib/cnpg-cluster/fleet.yaml
@@ -6,6 +6,7 @@ helm:
   releaseName: *name
   takeOwnership: true
   force: true
+  timeoutSeconds: 60
   waitForJobs: true
 dependsOn:
   - selector:

--- a/fleet/lib/cnpg-system/fleet.yaml
+++ b/fleet/lib/cnpg-system/fleet.yaml
@@ -8,6 +8,7 @@ helm:
   repo: https://cloudnative-pg.github.io/charts
   version: 0.21.6
   takeOwnership: true
+  timeoutSeconds: 60
   waitForJobs: true
   values:
     resources:

--- a/fleet/lib/external-secrets-conf/fleet.yaml
+++ b/fleet/lib/external-secrets-conf/fleet.yaml
@@ -6,6 +6,7 @@ labels:
   bundle: &name external-secrets-conf
 helm:
   releaseName: *name
+  timeoutSeconds: 60
   waitForJobs: true
   values:
     site: ${ .ClusterLabels.site }

--- a/fleet/lib/fleet-conf/fleet.yaml
+++ b/fleet/lib/fleet-conf/fleet.yaml
@@ -5,6 +5,8 @@ labels:
   bundle: &name fleet-conf
 helm:
   releaseName: *name
+  timeoutSeconds: 60
+  waitForJobs: true
 ignore:
   conditions:
     - type: Ready

--- a/fleet/lib/fluentbit/fleet.yaml
+++ b/fleet/lib/fluentbit/fleet.yaml
@@ -9,6 +9,7 @@ helm:
   releaseName: *name
   takeOwnership: true
   force: true
+  timeoutSeconds: 60
   waitForJobs: true
 dependsOn:
   - selector:

--- a/fleet/lib/htcondor/fleet.yaml
+++ b/fleet/lib/htcondor/fleet.yaml
@@ -2,6 +2,9 @@
 defaultNamespace: htcondor
 labels:
   bundle: &name htcondor
+helm:
+  timeoutSeconds: 60
+  waitForJobs: true
 dependsOn:
   - selector:
       matchLabels:

--- a/fleet/lib/ingress-nginx-lhn/fleet.yaml
+++ b/fleet/lib/ingress-nginx-lhn/fleet.yaml
@@ -28,6 +28,7 @@ helm:
             lsst.io/rule: "true"
     rbac:
       create: true
+  timeoutSeconds: 60
   waitForJobs: true
 targetCustomizations:
   - name: default

--- a/fleet/lib/ingress-nginx/fleet.yaml
+++ b/fleet/lib/ingress-nginx/fleet.yaml
@@ -61,6 +61,7 @@ helm:
                 severity: warning
     rbac:
       create: true
+  timeoutSeconds: 60
   waitForJobs: true
 targetCustomizations:
   - name: default

--- a/fleet/lib/keycloak-pg/fleet.yaml
+++ b/fleet/lib/keycloak-pg/fleet.yaml
@@ -6,6 +6,7 @@ labels:
   bundle: *name
 helm:
   releaseName: *name
+  timeoutSeconds: 60
   waitForJobs: true
 dependsOn:
   - selector:

--- a/fleet/lib/keycloak-pre/fleet.yaml
+++ b/fleet/lib/keycloak-pre/fleet.yaml
@@ -6,4 +6,5 @@ namespaceLabels:
   lsst.io/discover: "true"
 helm:
   releaseName: *name
+  timeoutSeconds: 60
   waitForJobs: true

--- a/fleet/lib/keycloak/fleet.yaml
+++ b/fleet/lib/keycloak/fleet.yaml
@@ -9,6 +9,7 @@ helm:
   releaseName: *name
   repo: https://charts.bitnami.com/bitnami
   version: 22.1.2
+  timeoutSeconds: 60
   waitForJobs: true
   valuesFiles:
     - values.yaml

--- a/fleet/lib/kyverno-conf/fleet.yaml
+++ b/fleet/lib/kyverno-conf/fleet.yaml
@@ -6,6 +6,7 @@ helm:
   releaseName: *name
   takeOwnership: true
   force: true
+  timeoutSeconds: 60
   waitForJobs: true
 dependsOn:
   - selector:

--- a/fleet/lib/metallb-conf/fleet.yaml
+++ b/fleet/lib/metallb-conf/fleet.yaml
@@ -6,6 +6,7 @@ helm:
   releaseName: *name
   takeOwnership: true
   force: true
+  timeoutSeconds: 60
   waitForJobs: true
 dependsOn:
   - selector:

--- a/fleet/lib/multus-conf/fleet.yaml
+++ b/fleet/lib/multus-conf/fleet.yaml
@@ -6,6 +6,7 @@ helm:
   releaseName: *name
   takeOwnership: true
   force: true
+  timeoutSeconds: 60
   waitForJobs: true
 dependsOn:
   - selector:

--- a/fleet/lib/multus-demo/fleet.yaml
+++ b/fleet/lib/multus-demo/fleet.yaml
@@ -5,6 +5,7 @@ labels:
 helm:
   releaseName: *name
   takeOwnership: true
+  timeoutSeconds: 60
   waitForJobs: true
 targetCustomizations:
   - name: kueyen

--- a/fleet/lib/nexus/fleet.yaml
+++ b/fleet/lib/nexus/fleet.yaml
@@ -9,6 +9,7 @@ helm:
   releaseName: *name
   repo: https://stevehipwell.github.io/helm-charts
   version: 5.0.0
+  timeoutSeconds: 60
   waitForJobs: true
   values:
     ingress:

--- a/fleet/lib/onepassword-connect/fleet.yaml
+++ b/fleet/lib/onepassword-connect/fleet.yaml
@@ -11,4 +11,5 @@ helm:
   version: 1.16.0
   valuesFiles:
     - values.yaml
+  timeoutSeconds: 60
   waitForJobs: true

--- a/fleet/lib/opensearch-logging/fleet.yaml
+++ b/fleet/lib/opensearch-logging/fleet.yaml
@@ -9,6 +9,7 @@ helm:
   releaseName: *name
   takeOwnership: true
   force: true
+  timeoutSeconds: 60
   waitForJobs: true
 dependsOn:
   - selector:

--- a/fleet/lib/opensearch-operator/fleet.yaml
+++ b/fleet/lib/opensearch-operator/fleet.yaml
@@ -15,3 +15,4 @@ helm:
     manager:
       logLevel: warn
   timeoutSeconds: 900
+  waitForJobs: true

--- a/fleet/lib/prometheus-alerts/fleet.yaml
+++ b/fleet/lib/prometheus-alerts/fleet.yaml
@@ -7,6 +7,7 @@ namespaceLabels:
 helm:
   releaseName: *name
   takeOwnership: true
+  timeoutSeconds: 60
   waitForJobs: true
 dependsOn:
   - selector:

--- a/fleet/lib/prometheus-operator-crds/fleet.yaml
+++ b/fleet/lib/prometheus-operator-crds/fleet.yaml
@@ -7,6 +7,7 @@ helm:
   releaseName: *name
   repo: https://prometheus-community.github.io/helm-charts
   version: 13.0.2
+  timeoutSeconds: 60
   takeOwnership: true
   force: true  # overwrite old crds
   waitForJobs: true

--- a/fleet/lib/rook-ceph/fleet.yaml
+++ b/fleet/lib/rook-ceph/fleet.yaml
@@ -11,6 +11,7 @@ helm:
   version: v1.15.2
   valuesFiles:
     - values.yaml
+  timeoutSeconds: 60
   waitForJobs: false
 dependsOn:
   - selector:

--- a/fleet/lib/strimzi-kafka-dashboards/fleet.yaml
+++ b/fleet/lib/strimzi-kafka-dashboards/fleet.yaml
@@ -7,5 +7,5 @@ namespaceLabels:
 helm:
   releaseName: *name
   takeOwnership: true
-  timeoutSeconds: 300
+  timeoutSeconds: 60
   waitForJobs: false

--- a/fleet/lib/velero-conf/fleet.yaml
+++ b/fleet/lib/velero-conf/fleet.yaml
@@ -6,6 +6,7 @@ helm:
   releaseName: *name
   takeOwnership: true
   force: true
+  timeoutSeconds: 60
   waitForJobs: true
 dependsOn:
   - selector:


### PR DESCRIPTION
It appears (???) that setting `helm.timeoutSeconds` may help resolve the "deadlocking" that has been observed where fleet never retries a bundle deployment.