### PR TITLE
(yagan/htcondor) fix comcam-archiver NFS to nfs3.cp

### DIFF
--- a/fleet/lib/htcondor/overlays/yagan/deployment-htcondor-worker.yaml
+++ b/fleet/lib/htcondor/overlays/yagan/deployment-htcondor-worker.yaml
@@ -65,16 +65,16 @@ spec:
           server: nfs-auxtel.cp.lsst.org
       - name: lsstcomcam
         nfs:
-          path: /repo/LSSTComCam
-          server: comcam-archiver.cp.lsst.org
+          path: /comcam/repo/LSSTComCam
+          server: nfs3.cp.lsst.org
       - name: lsstdata-other
         nfs:
           path: /lsstdata
           server: nfs1.cp.lsst.org
       - name: lsstdata-comcam
         nfs:
-          path: /lsstdata
-          server: comcam-archiver.cp.lsst.org
+          path: /comcam/lsstdata
+          server: nfs3.cp.lsst.org
       - name: lsstdata-auxtel
         nfs:
           path: /auxtel/lsstdata


### PR DESCRIPTION
on `IT-5692` it was decided to move the NFS from `comcam-archiver.cp` into the `nfs3.cp` this broke somethings including `HTCondor`
this PR goes great with https://github.com/lsst-it/lsst-control/pull/1485