### PR TITLE
(fleet/rook-ceph-cluster) Lower CPU request osd/mon

### DIFF
--- a/fleet/lib/rook-ceph-cluster/values.yaml
+++ b/fleet/lib/rook-ceph-cluster/values.yaml
@@ -127,7 +127,7 @@ cephClusterSpec:
         cpu: "2"
         memory: 12Gi
       requests:
-        cpu: "1"
+        cpu: "500"
         memory: 8Gi
     prepareosd:
       limits:


### PR DESCRIPTION
due to the lost of `pillan06`, resources need to be controlled, setting overlays is the recommended option due to different clusters and requirements. but in overall on main clusters, resources for `monitor pods` and `osd` look way high compared to `request` and `limit` configuration.

see [values.yaml](https://github.com/lsst-it/k8s-cookbook/blob/427c280bdaa1c09e2fb1529d42fb1ea24287de70/fleet/lib/rook-ceph-cluster/values.yaml#L110)

this PR is based on this pull from clusters

```
Cluster: ruka
CPU use on rook-ceph 'osd' o 'mon':
rook-ceph-osd-2-7d77c58d4b-46wkd 69m
rook-ceph-osd-3-5ddc76b-jkcvc 67m
rook-ceph-osd-4-56ddd6576f-nmqx5 61m
rook-ceph-mon-d-5bdc567795-7dm5d 56m
rook-ceph-mon-a-647bc5549-7qb8v 46m
rook-ceph-osd-0-6cf76787dd-r5btz 32m
-----------------------------------
Cluster: kueyen
CPU use on rook-ceph 'osd' o 'mon':
rook-ceph-osd-3-578c46f77c-hjstz 71m
rook-ceph-osd-9-64d67d9f4b-9bfqt 63m
rook-ceph-osd-8-7bd677dd75-5pmhl 63m
rook-ceph-osd-4-679db5f785-brfbx 58m
rook-ceph-osd-0-bc8ff8d77-swtjn 55m
rook-ceph-osd-11-86c785ddb8-8lcnb 54m
-----------------------------------
Cluster: manke
CPU use on rook-ceph 'osd' o 'mon':
rook-ceph-mon-a-cbbc845f9-tgx2t 44m
rook-ceph-mon-d-68fc86c467-4bwj5 44m
rook-ceph-mon-i-77b4695b6b-sk9tb 37m
rook-ceph-mon-h-67c9cdff6c-hxq7m 34m
rook-ceph-osd-115-7b645cd99b-7rxpm 33m
rook-ceph-osd-82-66865bf69c-8rff9 27m
-----------------------------------
Cluster: konkong
CPU use on rook-ceph 'osd' o 'mon':
rook-ceph-osd-8-7f74c6b58f-5br54 22m
rook-ceph-osd-36-6cf7796995-2h9qq 21m
rook-ceph-osd-30-9dd9b494-n82nv 20m
rook-ceph-osd-40-65d7d6c7f5-jnxq8 19m
rook-ceph-osd-26-88b8565c7-r5mrj 19m
rook-ceph-osd-42-664dd67f-5twjs 19m
-----------------------------------
Cluster: yagan
CPU use on rook-ceph 'osd' o 'mon':
rook-ceph-osd-106-644c4845ff-bgr8v 24m
rook-ceph-osd-43-c5958b666-nrvj7 24m
rook-ceph-osd-53-58dddff9d8-kwpsc 23m
rook-ceph-osd-33-6d8b9f5978-mhjd9 23m
rook-ceph-osd-64-5dd4fb65f6-bmtsj 23m
rook-ceph-osd-61-5786599cbd-sdpll 22m
-----------------------------------
Cluster: chonchon
CPU use on rook-ceph 'osd' o 'mon':
rook-ceph-osd-26-7d8666989b-fnhsw 72m
rook-ceph-osd-30-c77d9bfc6-l7mcm 53m
rook-ceph-osd-11-5db4d7c5ff-rsvcp 43m
rook-ceph-osd-9-66c64b5777-lclxs 35m
rook-ceph-osd-29-5cb6cdc945-wk492 33m
rook-ceph-osd-7-75f9f58467-qlg7k 31m
-----------------------------------```