### PR TITLE
(fleet/rook-ceph-cluster) fix ceph dashboard ingress

### DIFF
--- a/fleet/lib/rook-ceph-cluster/values.yaml
+++ b/fleet/lib/rook-ceph-cluster/values.yaml
@@ -169,12 +169,9 @@ ingress:
   dashboard:
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
-      kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-      nginx.ingress.kubernetes.io/server-snippet: |
-        proxy_ssl_verify off;
     host:
       name: &hostname ceph.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org
+    ingressClassName: nginx
     tls:
       - hosts:
           - *hostname


### PR DESCRIPTION
The mgr pod dashboard port now (properly) has tls disabled.