### PR TITLE
({chonchon,elqui,konkong,pillan,ruka}) add lfa users for oods

### DIFF
--- a/fleet/lib/external-secrets-conf/fleet.yaml
+++ b/fleet/lib/external-secrets-conf/fleet.yaml
@@ -10,10 +10,12 @@ helm:
   waitForJobs: true
   values:
     site: ${ .ClusterLabels.site }
-    vaults:
-      ${ .ClusterName }.${ .ClusterLabels.site }: 1
-      k8s-${ .ClusterLabels.site }: 2
-      k8s-common: 3
+    clusterSecretStores:
+      onepassword:
+        vaults:
+          ${ .ClusterName }.${ .ClusterLabels.site }: 1
+          k8s-${ .ClusterLabels.site }: 2
+          k8s-common: 3
 dependsOn:
   - selector:
       matchLabels:
@@ -34,3 +36,28 @@ targetCustomizations:
           ${ .ClusterName }.${ .ClusterLabels.site }: ~
           # it probaly would have been easier to name the vaults local.<site>...
           rancher.${ .ClusterLabels.site }: 1
+  - name: oods-cluster
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - chonchon
+            - elqui
+            - konkong
+            - pillan
+            - ruka
+    helm:
+      values:
+        clusterSecretStores:
+          onepassword-oods:
+            vaults:
+              oods.${ .ClusterLabels.site }: 1
+  - name: elqui  # will replace chonchon
+    clusterName: elqui
+    helm:
+      values:
+        clusterSecretStores:
+          onepassword-oods:
+            vaults:
+              oods.elqui: 1

--- a/fleet/lib/external-secrets-conf/templates/clustersecretstore-onepassword.yaml
+++ b/fleet/lib/external-secrets-conf/templates/clustersecretstore-onepassword.yaml
@@ -1,19 +1,20 @@
 # yamllint disable-file
+{{- range $name, $v := .Values.clusterSecretStores }}
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
-  name: onepassword
-  namespace: external-secrets
+  name: {{ $name }}
 spec:
   provider:
     onepassword:
-      connectHost: https://connect.{{ .Values.site }}.lsst.org
+      connectHost: https://connect.{{ $.Values.site }}.lsst.org
       vaults:
-{{ toYaml .Values.vaults | indent 8 }}
+{{ toYaml $v.vaults | indent 8 }}
       auth:
         secretRef:
           connectTokenSecretRef:
             name: onepassword-connect-token
             key: token
             namespace: external-secrets
+{{- end }}

--- a/fleet/lib/rook-ceph-conf/charts/chonchon/templates/cephobjectstoreuser-butler.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/chonchon/templates/cephobjectstoreuser-butler.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: butler
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 2
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-lfa-butler
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-lfa-butler
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: butler
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: butler
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/chonchon/templates/cephobjectstoreuser-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/chonchon/templates/cephobjectstoreuser-latiss.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: latiss
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 1
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-lfa-latiss
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-lfa-latiss
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: latiss
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: latiss
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/chonchon/templates/cephobjectstoreuser-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/chonchon/templates/cephobjectstoreuser-lsstcam.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: lsstcam
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 1
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-lfa-lsstcam
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-lfa-lsstcam
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: lsstcam
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: lsstcam
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/chonchon/templates/cephobjectstoreuser-oods-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/chonchon/templates/cephobjectstoreuser-oods-latiss.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: oods-latiss
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-oods-latiss
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-oods-latiss
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: oods-latiss
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: oods-latiss
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/chonchon/templates/cephobjectstoreuser-oods-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/chonchon/templates/cephobjectstoreuser-oods-lsstcam.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: oods-lsstcam
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-oods-lsstcam
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-oods-lsstcam
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: oods-lsstcam
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: oods-lsstcam
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-butler.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-butler.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: butler
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 2
+    maxSize: 2Pi
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-lfa-butler
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-lfa-butler
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: butler
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: butler
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-latiss.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: latiss
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 1
+    maxSize: 100Ti
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-lfa-latiss
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-lfa-latiss
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: latiss
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: latiss
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-lsstcam.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: lsstcam
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 1
+    maxSize: 1Pi
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-lfa-lsstcam
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-lfa-lsstcam
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: lsstcam
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: lsstcam
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-oods-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-oods-latiss.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: oods-latiss
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-oods-latiss
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-oods-latiss
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: oods-latiss
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: oods-latiss
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-oods-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-oods-lsstcam.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: oods-lsstcam
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-oods-lsstcam
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-oods-lsstcam
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: oods-lsstcam
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: oods-lsstcam
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstoreuser-butler.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstoreuser-butler.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: butler
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 2
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-lfa-butler
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-lfa-butler
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: butler
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: butler
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstoreuser-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstoreuser-latiss.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: latiss
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 1
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-lfa-latiss
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-lfa-latiss
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: latiss
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: latiss
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstoreuser-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstoreuser-lsstcam.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: lsstcam
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 1
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-lfa-lsstcam
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-lfa-lsstcam
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: lsstcam
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: lsstcam
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstoreuser-oods-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstoreuser-oods-latiss.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: oods-latiss
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-oods-latiss
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-oods-latiss
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: oods-latiss
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: oods-latiss
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstoreuser-oods-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstoreuser-oods-lsstcam.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: oods-lsstcam
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-oods-lsstcam
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-oods-lsstcam
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: oods-lsstcam
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: oods-lsstcam
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstoreuser-butler.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstoreuser-butler.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: butler
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 2
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-lfa-butler
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-lfa-butler
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: butler
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: butler
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstoreuser-comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstoreuser-comcam.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: comcam
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 1
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-lfa-comcam
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-lfa-comcam
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: comcam
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: comcam
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstoreuser-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstoreuser-latiss.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: latiss
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 1
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-lfa-latiss
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-lfa-latiss
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: latiss
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: latiss
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstoreuser-oods-comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstoreuser-oods-comcam.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: oods-comcam
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-oods-comcam
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-oods-comcam
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: oods-comcam
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: oods-comcam
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstoreuser-oods-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstoreuser-oods-latiss.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: oods-latiss
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-oods-latiss
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-oods-latiss
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: oods-latiss
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: oods-latiss
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstoreuser-butler.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstoreuser-butler.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: butler
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 2
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-lfa-butler
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-lfa-butler
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: butler
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: butler
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstoreuser-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstoreuser-latiss.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: latiss
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 1
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-lfa-latiss
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-lfa-latiss
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: latiss
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: latiss
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstoreuser-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstoreuser-lsstcam.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: lsstcam
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 1
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-lfa-lsstcam
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-lfa-lsstcam
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: lsstcam
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: lsstcam
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstoreuser-oods-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstoreuser-oods-latiss.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: oods-latiss
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-oods-latiss
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-oods-latiss
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: oods-latiss
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: oods-latiss
+          property: AWS_SECRET_ACCESS_KEY

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstoreuser-oods-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstoreuser-oods-lsstcam.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: oods-lsstcam
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-oods-lsstcam
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-oods-lsstcam
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: oods-lsstcam
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: oods-lsstcam
+          property: AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
The following 1pass vaults have been created to support the push of the rgw user credentials:

- oods.dev
- oods.tu
- oods.ls
- oods.cp
- oods.elqui (temporary)