### PR TITLE
(site/cp) bump rke to v1.29.8-rancher1-1

### DIFF
--- a/chonchon/rke/cluster.yml
+++ b/chonchon/rke/cluster.yml
@@ -55,6 +55,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.28.12-rancher1-1
+kubernetes_version: v1.29.8-rancher1-1
 ingress:
   provider: none

--- a/lukay/rke/cluster.yml
+++ b/lukay/rke/cluster.yml
@@ -46,6 +46,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.28.12-rancher1-1
+kubernetes_version: v1.29.8-rancher1-1
 ingress:
   provider: none

--- a/rancher.cp/rke/cluster.yml
+++ b/rancher.cp/rke/cluster.yml
@@ -31,6 +31,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.28.12-rancher1-1
+kubernetes_version: v1.29.8-rancher1-1
 ingress:
   provider: none

--- a/yagan/rke/cluster.yml
+++ b/yagan/rke/cluster.yml
@@ -166,6 +166,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.28.12-rancher1-1
+kubernetes_version: v1.29.8-rancher1-1
 ingress:
   provider: none

--- a/yepun/rke/cluster.yml
+++ b/yepun/rke/cluster.yml
@@ -55,6 +55,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.28.12-rancher1-1
+kubernetes_version: v1.29.8-rancher1-1
 ingress:
   provider: none


### PR DESCRIPTION
this will move k8s version on cp clusters to v1.29.8 so close the October loop.
this goes great with PR https://github.com/lsst-it/lsst-control/pull/1501
