### PR TITLE
(yagan/htcondor) add initContainer to do symlinks

### DIFF
--- a/fleet/lib/htcondor/overlays/yagan/deployment-htcondor-worker.yaml
+++ b/fleet/lib/htcondor/overlays/yagan/deployment-htcondor-worker.yaml
@@ -17,6 +17,17 @@ spec:
       labels:
         app: htcondor-worker
     spec:
+      initContainers:
+      - name: init-symlinks
+        image: busybox
+        command: [sh, -c, ln -s /readonly/lsstdata/comcam/base/comcam /data/lsstdata/base/comcam && ln -s /readonly/lsstdata/auxtel/base/auxtel /data/lsstdata/base/auxtel]
+        volumeMounts:
+        - name: lsstdata-comcam
+          mountPath: /readonly/lsstdata/comcam
+        - name: lsstdata-auxtel
+          mountPath: /readonly/lsstdata/auxtel
+        - name: lsstdata-symlinks
+          mountPath: /data/lsstdata/base
       containers:
       - name: htcondor-worker
         image: docker.io/lsstit/htcondor-worker:23
@@ -43,10 +54,8 @@ spec:
           mountPath: /readonly/lsstdata/comcam
         - name: lsstdata-auxtel
           mountPath: /readonly/lsstdata/auxtel
-        - name: lsstdata-comcam
-          mountPath: /data/lsstdata/
-        - name: lsstdata-auxtel
-          mountPath: /data/lsstdata/
+        - name: lsstdata-symlinks
+          mountPath: /data/lsstdata/base
         ports:
         - containerPort: 9618
           protocol: TCP
@@ -83,3 +92,5 @@ spec:
         nfs:
           path: /auxtel/lsstdata
           server: nfs-auxtel.cp.lsst.org
+      - name: lsstdata-symlinks
+        emptyDir: {}


### PR DESCRIPTION
1st try - I tried to mount the `comcam` and `auxtel` NFS using the same `volumes`, but changing the `volumeMounts` Paths, but that didnt work...

2nd try - I tried to specify new volumes with more explicit path into the target folder, but got permission issues.

3rd try - success... i pulled an `initContainer`, created a `emptyDir`, mounted all, created the symlink and let it die in peace while the main container has the same `emptyDir` attached.



