### PR TITLE
(fleet/ingress-nginx) fix ingressClassName support

### DIFF
--- a/fleet/lib/ingress-nginx-lhn/fleet.yaml
+++ b/fleet/lib/ingress-nginx-lhn/fleet.yaml
@@ -14,8 +14,11 @@ helm:
       kind: DaemonSet
       allowSnippetAnnotations: true
       ingressClass: nginx-lhn
+      ingressClassByName: true
       ingressClassResource:
         name: nginx-lhn
+        enabled: true
+        controllerValue: k8s.io/ingress-nginx-lhn
       metrics:
         enabled: true
         serviceMonitor:

--- a/fleet/lib/ingress-nginx/fleet.yaml
+++ b/fleet/lib/ingress-nginx/fleet.yaml
@@ -13,6 +13,12 @@ helm:
     controller:
       kind: DaemonSet
       allowSnippetAnnotations: true
+      ingressClass: nginx
+      ingressClassByName: true
+      ingressClassResource:
+        name: nginx
+        enabled: true
+        controllerValue: k8s.io/ingress-nginx
       metrics:
         enabled: true
         serviceMonitor:


### PR DESCRIPTION
Migrating from ingress class annotations to the `ing.spec.ingressClassName` field caused the multiple ingress controllers to start fighting over ing resources due to misconfiguration.