### PR TITLE
(fleet/rook-ceph-cluster) allow ceph topic configuration without TLS

### DIFF
--- a/fleet/lib/rook-ceph-cluster/values.yaml
+++ b/fleet/lib/rook-ceph-cluster/values.yaml
@@ -37,6 +37,9 @@ cephClusterSpec:
   labels:
     monitoring:
       lsst.io/monitor: "true"
+  cephConfig:
+    global:
+      rgw_allow_notification_secrets_in_cleartext: "true"
   dataDirHostPath: /var/lib/rook
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false


### PR DESCRIPTION
Ceph, by default, does not allow http basic auth to be set in the kafka URI unless rgw TLS is enabled.  As we terminate TLS with the ingress controller, and the communication between the ingress controller and rgw is HTTP(no-s), we need to disable this sanity check.