### PR TITLE
(fleet/rook-ceph-conf) rm usage of cephnfs.spec.rados.namespace

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/chonchon/templates/cephnfs-obs-env.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/chonchon/templates/cephnfs-obs-env.yaml
@@ -37,8 +37,6 @@ metadata:
 spec:
   rados:
     pool: obs-env-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/gaw/templates/cephnfs-backup.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/gaw/templates/cephnfs-backup.yaml
@@ -33,8 +33,6 @@ metadata:
 spec:
   rados:
     pool: backup-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/kueyen/templates/cephnfs-auxtel.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/kueyen/templates/cephnfs-auxtel.yaml
@@ -45,8 +45,6 @@ metadata:
 spec:
   rados:
     pool: auxtel-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/lukay/templates/cephnfs-backup.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/lukay/templates/cephnfs-backup.yaml
@@ -33,8 +33,6 @@ metadata:
 spec:
   rados:
     pool: backup-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/manke/templates/cephnfs-auxtel.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/manke/templates/cephnfs-auxtel.yaml
@@ -45,8 +45,6 @@ metadata:
 spec:
   rados:
     pool: auxtel-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/manke/templates/cephnfs-comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/manke/templates/cephnfs-comcam.yaml
@@ -45,8 +45,6 @@ metadata:
 spec:
   rados:
     pool: comcam-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/manke/templates/cephnfs-jhome.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/manke/templates/cephnfs-jhome.yaml
@@ -37,8 +37,6 @@ metadata:
 spec:
   rados:
     pool: jhome-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/manke/templates/cephnfs-lsstdata.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/manke/templates/cephnfs-lsstdata.yaml
@@ -37,8 +37,6 @@ metadata:
 spec:
   rados:
     pool: lsstdata-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/manke/templates/cephnfs-obsenv.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/manke/templates/cephnfs-obsenv.yaml
@@ -37,8 +37,6 @@ metadata:
 spec:
   rados:
     pool: obs-env-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/manke/templates/cephnfs-project.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/manke/templates/cephnfs-project.yaml
@@ -37,8 +37,6 @@ metadata:
 spec:
   rados:
     pool: project-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/manke/templates/cephnfs-scratch.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/manke/templates/cephnfs-scratch.yaml
@@ -37,8 +37,6 @@ metadata:
 spec:
   rados:
     pool: scratch-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/namkueyen/templates/cephnfs-auxtel.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/namkueyen/templates/cephnfs-auxtel.yaml
@@ -45,8 +45,6 @@ metadata:
 spec:
   rados:
     pool: auxtel-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-auxtel.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-auxtel.yaml
@@ -37,8 +37,6 @@ metadata:
 spec:
   rados:
     pool: auxtel-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-comcam.yaml
@@ -37,8 +37,6 @@ metadata:
 spec:
   rados:
     pool: comcam-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-jhome.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-jhome.yaml
@@ -37,8 +37,6 @@ metadata:
 spec:
   rados:
     pool: jhome-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-lsstdata.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-lsstdata.yaml
@@ -37,8 +37,6 @@ metadata:
 spec:
   rados:
     pool: lsstdata-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-obs-env.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-obs-env.yaml
@@ -37,8 +37,6 @@ metadata:
 spec:
   rados:
     pool: obs-env-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-project.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-project.yaml
@@ -37,8 +37,6 @@ metadata:
 spec:
   rados:
     pool: project-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-rsphome.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-rsphome.yaml
@@ -45,8 +45,6 @@ metadata:
 spec:
   rados:
     pool: rsphome-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-scratch.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephnfs-scratch.yaml
@@ -37,8 +37,6 @@ metadata:
 spec:
   rados:
     pool: scratch-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephnfs-auxtel.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephnfs-auxtel.yaml
@@ -45,8 +45,6 @@ metadata:
 spec:
   rados:
     pool: auxtel-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/yagan/templates/cephnfs-auxtel.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/yagan/templates/cephnfs-auxtel.yaml
@@ -37,8 +37,6 @@ metadata:
 spec:
   rados:
     pool: auxtel-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:

--- a/fleet/lib/rook-ceph-conf/charts/yagan/templates/cephnfs-comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/yagan/templates/cephnfs-comcam.yaml
@@ -37,8 +37,6 @@ metadata:
 spec:
   rados:
     pool: comcam-data0
-    # RADOS namespace where NFS client recovery data is stored in the pool.
-    namespace: nfs-ns
   server:
     active: 1
     resources:


### PR DESCRIPTION
This field is deprecated and has no effect.

```
 ~ $ k explain cephnfs.spec.rados.namespace
GROUP:      ceph.rook.io
KIND:       CephNFS
VERSION:    v1

FIELD: namespace <string>

DESCRIPTION:
    The namespace inside the Ceph pool (set by 'pool') where shared NFS-Ganesha
    config is stored.
    This setting is deprecated as it is internally set to the name of the
    CephNFS.
    

```