### PR TITLE
(fleet/multus) add configuration for ra-lhn on kueyen and yagan with demos

### DIFF
--- a/fleet/lib/multus-conf/overlays/kueyen/net-attach-def-ra-lhn.yaml
+++ b/fleet/lib/multus-conf/overlays/kueyen/net-attach-def-ra-lhn.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ra-lhn
+  namespace: kube-system
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "type": "macvlan",
+    "master": "ens2f0",
+    "mode": "bridge",
+    "ipam": {
+      "type": "static",
+      "addresses": [
+        {
+          "address": "192.168.1.10/24",
+          "gateway": "192.168.1.254"
+        }
+      ]
+    }
+  }'

--- a/fleet/lib/multus-conf/overlays/yagan/net-attach-def-ra-lhn-demo.yaml
+++ b/fleet/lib/multus-conf/overlays/yagan/net-attach-def-ra-lhn-demo.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ra-lhn-demo
+  namespace: kube-system
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "type": "macvlan",
+    "master": "br1702",
+    "mode": "bridge",
+    "ipam": {
+      "type": "static",
+      "addresses": [
+        {
+          "address": "139.229.173.162/27",
+          "gateway": "139.229.173.190"
+        }
+      ]
+    }
+  }'

--- a/fleet/lib/multus-conf/overlays/yagan/net-attach-def-ra-lhn.yaml
+++ b/fleet/lib/multus-conf/overlays/yagan/net-attach-def-ra-lhn.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ra-lhn
+  namespace: kube-system
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "type": "macvlan",
+    "master": "br1702",
+    "mode": "bridge",
+    "ipam": {
+      "type": "static",
+      "addresses": [
+        {
+          "address": "139.229.173.161/27",
+          "gateway": "139.229.173.190"
+        }
+      ]
+    }
+  }'

--- a/fleet/lib/multus-demo/fleet.yaml
+++ b/fleet/lib/multus-demo/fleet.yaml
@@ -14,6 +14,7 @@ targetCustomizations:
       values:
         networks:
           - dds
+          - ra-lhn
   - name: ruka
     clusterName: ruka
     helm:
@@ -47,3 +48,4 @@ targetCustomizations:
         networks:
           - dds
           - lhn
+          - ra-lhn-demo


### PR DESCRIPTION
static configuration for 1 IP address that the Rapid Analysis will use to reach the USDF (tested on Kueyen working)
still need to add the CNI Plugin...