### PR TITLE
(fleet/rook-ceph-cluster) remove disk manke08-10

### DIFF
--- a/fleet/lib/rook-ceph-cluster/overlays/manke/values.yaml
+++ b/fleet/lib/rook-ceph-cluster/overlays/manke/values.yaml
@@ -43,21 +43,6 @@ cephClusterSpec:
           - name: /dev/disk/by-id/nvme-SAMSUNG_MZQL21T9HCJR-00A07_S64GNE0T301068
           - name: /dev/disk/by-id/nvme-SAMSUNG_MZQL21T9HCJR-00A07_S64GNE0T300787
           - name: /dev/disk/by-id/nvme-SAMSUNG_MZQL21T9HCJR-00A07_S64GNE0T301048
-      - name: manke08
-        devices:
-          - name: /dev/disk/by-id/nvme-SAMSUNG_MZQL21T9HCJR-00A07_S64GNE0T301067
-          - name: /dev/disk/by-id/nvme-SAMSUNG_MZQL21T9HCJR-00A07_S64GNE0T301313
-          - name: /dev/disk/by-id/nvme-SAMSUNG_MZQL21T9HCJR-00A07_S64GNE0T301030
-      - name: manke09
-        devices:
-          - name: /dev/disk/by-id/nvme-SAMSUNG_MZQL21T9HCJR-00A07_S64GNE0T301065
-          - name: /dev/disk/by-id/nvme-SAMSUNG_MZQL21T9HCJR-00A07_S64GNE0T301022
-          - name: /dev/disk/by-id/nvme-SAMSUNG_MZQL21T9HCJR-00A07_S64GNE0T300788
-      - name: manke10
-        devices:
-          - name: /dev/disk/by-id/nvme-SAMSUNG_MZQL21T9HCJR-00A07_S64GNE0T301061
-          - name: /dev/disk/by-id/nvme-SAMSUNG_MZQL21T9HCJR-00A07_S64GNE0T301031
-          - name: /dev/disk/by-id/nvme-SAMSUNG_MZQL21T9HCJR-00A07_S64GNE0T301939
 
 cephBlockPools:
   - name: replicapool


### PR DESCRIPTION
currently rook on manke is:

> --- RAW STORAGE ---
> CLASS    SIZE   AVAIL    USED  RAW USED  %RAW USED
> nvme   52 TiB  30 TiB  22 TiB    22 TiB      42.39
> TOTAL  52 TiB  30 TiB  22 TiB    22 TiB      42.39

if we remove 3 disk 1.7T from these 3 nodes (15,3Tb~) Manke's Rook can still hold 14,7Tb~ 
but maybe the idea is to move this disk to another nodes.