### PR TITLE
(ruka) rm rook-ceph/rook-ceph-object-user-lfa-loki pushsecret

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstoreuser-loki.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstoreuser-loki.yaml
@@ -7,27 +7,3 @@ metadata:
 spec:
   store: lfa
   clusterNamespace: rook-ceph
----
-apiVersion: external-secrets.io/v1alpha1
-kind: PushSecret
-metadata:
-  name: rook-ceph-object-user-lfa-loki
-  namespace: rook-ceph
-spec:
-  secretStoreRefs:
-    - kind: ClusterSecretStore
-      name: onepassword-ruka.dev
-  selector:
-    secret:
-      name: rook-ceph-object-user-lfa-loki
-  data:
-    - match:
-        secretKey: AccessKey
-        remoteRef:
-          remoteKey: loki
-          property: AWS_ACCESS_KEY_ID
-    - match:
-        secretKey: SecretKey
-        remoteRef:
-          remoteKey: loki
-          property: AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
This pushsecret is referencing a clustersecretstore which does not exist. Nor does this secret need to be pushed to 1pass.

Resolves this fleet error:

    NotReady(1) [Bundle ruka-fleet-s-dev-c-ruka-rook-ceph-conf]; pushsecret.external-secrets.io rook-ceph/rook-ceph-object-user-lfa-loki [progressing] could not get ClusterSecretStore "onepassword-ruka.dev", ClusterSecretStore.external-secrets.io "onepassword-ruka.dev" not found