### PR TITLE
(lfa/policies) add Lifecycle 30 days to LFA in the Summit

### DIFF
--- a/chonchon/rook-ceph/s3/README.md
+++ b/chonchon/rook-ceph/s3/README.md
@@ -1,0 +1,13 @@
+# Lifecycle
+
+## Lifecycle Policy Configuration for Buckets
+
+```bash
+aws s3api put-bucket-lifecycle-configuration --profile lfa-cp --no-verify-ssl --region lfa --bucket rubinobs-lfa-cp --lifecycle-configuration file://lfa-cp-lifecycle.json
+```
+
+## Check Current Policy
+
+```bash
+aws s3api get-bucket-lifecycle-configuration --profile lfa-cp --no-verify-ssl --region lfa --bucket rubinobs-lfa-cp
+```

--- a/chonchon/rook-ceph/s3/lfa-cp-lifecycle.json
+++ b/chonchon/rook-ceph/s3/lfa-cp-lifecycle.json
@@ -1,0 +1,15 @@
+{
+    "Rules": [
+        {
+            "Expiration": {
+                "Days": 30
+            },
+            "ID": "30DaysRetention",
+            "Prefix": "",
+            "Status": "Enabled",
+            "AbortIncompleteMultipartUpload":{
+              "DaysAfterInitiation":1
+            }
+        }
+    ]
+}


### PR DESCRIPTION
this was authorized and re-asked in the CAP Meeting on Nov 19th... according to KT, the LFA replication at the USDF only gets 1 day behind at worst scenario, so 30 days is good for the replication.
this is the last LFA without LifeCycle. 