### PR TITLE
(fleet/multus) raise request/limits on pod

### DIFF
--- a/fleet/lib/multus/multus-daemonset-thick.yml
+++ b/fleet/lib/multus/multus-daemonset-thick.yml
@@ -162,10 +162,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 64Mi
+              memory: 128Mi
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: 256Mi
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
Multus is tight on memory and has some restarts on Yagan... (20~ restarts, 75% used Memory)