### PR TITLE
(rook-ceph/konkong) add calib user/bucket/quota/policies

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstoreuser-calib.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstoreuser-calib.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: calib
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: rook-ceph-object-user-lfa-calib
+  namespace: rook-ceph
+spec:
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword-oods
+  selector:
+    secret:
+      name: rook-ceph-object-user-lfa-calib
+  data:
+    - match:
+        secretKey: AccessKey
+        remoteRef:
+          remoteKey: calib
+          property: AWS_ACCESS_KEY_ID
+    - match:
+        secretKey: SecretKey
+        remoteRef:
+          remoteKey: calib
+          property: AWS_SECRET_ACCESS_KEY

--- a/konkong/rook-ceph/s3/README.md
+++ b/konkong/rook-ceph/s3/README.md
@@ -16,6 +16,7 @@ radosgw-admin user create --uid=lsstcam --display-name="lsstcam account" --rgw-z
 radosgw-admin user create --uid=butler  --display-name="butler account"  --rgw-zone=s3-butler --rgw-zonegroup=s3-butler --rgw-realm=s3-butler --access-key= --secret-key=
 radosgw-admin user create --uid=oods-latiss  --display-name="oods latiss account"  --rgw-zone=s3-butler --rgw-zonegroup=s3-butler --rgw-realm=s3-butler --access-key= --secret-key=
 radosgw-admin user create --uid=oods-lsstcam  --display-name="oods lsstcam account"  --rgw-zone=s3-butler --rgw-zonegroup=s3-butler --rgw-realm=s3-butler --access-key= --secret-key=
+radosgw-admin user create --uid=calib  --display-name="calib account"  --rgw-zone=s3-butler --rgw-zonegroup=s3-butler --rgw-realm=s3-butler --access-key= --secret-key=
 ```
 
 ## Bucket Creation and Quotas
@@ -40,6 +41,11 @@ aws s3 --profile s3-bts-lsstcam mb s3://rubinobs-butler-lsstcam --endpoint-url h
 radosgw-admin quota set --bucket=rubinobs-butler-lsstcam --rgw-zone=s3-butler --rgw-zonegroup=s3-butler --rgw-realm=s3-butler --quota-scope=bucket --max-size=34T
 radosgw-admin quota enable --bucket=rubinobs-butler-lsstcam --rgw-zone=s3-butler --rgw-zonegroup=s3-butler --rgw-realm=s3-butler
 radosgw-admin bucket stats --bucket=rubinobs-butler-lsstcam --rgw-realm=s3-butler
+
+aws s3 --profile s3-bts-calib mb s3://rubinobs-calibrations --endpoint-url https://s3-butler.ls.lsst.org --region s3-butler
+bash-5.1$ radosgw-admin quota set --bucket=rubinobs-calibrations --rgw-zone=s3-butler --rgw-zonegroup=s3-butler --rgw-realm=s3-butler --quota-scope=bucket --max-size=4T
+bash-5.1$ radosgw-admin quota enable --bucket=rubinobs-calibrations --rgw-zone=s3-butler --rgw-zonegroup=s3-butler --rgw-realm=s3-butler
+bash-5.1$ radosgw-admin bucket stats --bucket=rubinobs-calibrations --rgw-realm=s3-butler
 ```
 
 ## Apply Policies to the Buckets
@@ -49,6 +55,7 @@ aws s3api --profile s3-bts-latiss put-bucket-policy --bucket rubinobs-raw-latiss
 aws s3api --profile s3-bts-latiss put-bucket-policy --bucket rubinobs-butler-latiss --policy file://users-rubinobs-butler-latiss-policy.json --endpoint-url https://s3-butler.ls.lsst.org --region s3-butler
 aws s3api --profile s3-bts-lsstcam put-bucket-policy --bucket rubinobs-raw-lsstcam --policy file://users-rubinobs-raw-lsstcam-policy.json --endpoint-url https://s3-butler.ls.lsst.org --region s3-butler
 aws s3api --profile s3-bts-lsstcam put-bucket-policy --bucket rubinobs-butler-lsstcam --policy file://users-rubinobs-butler-lsstcam-policy.json --endpoint-url https://s3-butler.ls.lsst.org --region s3-butler
+aws s3api --profile s3-bts-calib put-bucket-policy --bucket rubinobs-calibrations --policy file://users-rubinobs-calibrations-policy.json --endpoint-url https://s3-butler.ls.lsst.org --region s3-butler
 ```
 
 ## Lifecycle Policy Configuration for Buckets

--- a/konkong/rook-ceph/s3/users-rubinobs-calibrations-policy.json
+++ b/konkong/rook-ceph/s3/users-rubinobs-calibrations-policy.json
@@ -1,0 +1,50 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam:::user/butler"
+            },
+            "Action": [
+                "s3:GetObject",
+                "s3:ListBucket",
+                "s3:GetBucketLocation"
+            ],
+            "Resource": [
+                "arn:aws:s3:::rubinobs-calibrations",
+                "arn:aws:s3:::rubinobs-calibrations/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam:::user/oods-latiss"
+            },
+            "Action": [
+                "s3:GetObject",
+                "s3:ListBucket",
+                "s3:GetBucketLocation"
+            ],
+            "Resource": [
+                "arn:aws:s3:::rubinobs-calibrations",
+                "arn:aws:s3:::rubinobs-calibrations/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam:::user/oods-lsstcam"
+            },
+            "Action": [
+                "s3:GetObject",
+                "s3:ListBucket",
+                "s3:GetBucketLocation"
+            ],
+            "Resource": [
+                "arn:aws:s3:::rubinobs-calibrations",
+                "arn:aws:s3:::rubinobs-calibrations/*"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Calibrations need to go inside their own bucket with his own user. (`calib`)
quota needs to be set at `4TB`
users:
- `butler`
- `oods-lsstcam`
- `oods-latiss`
need READ Permissions. (policy done)

README.md updated