### PR TITLE
(fleet/rook-ceph-conf) buff quota for olly on konkong

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-o11y.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-o11y.yaml
@@ -17,7 +17,7 @@ spec:
       dataChunks: 2
       codingChunks: 1
     quotas:
-      maxSize: 3.0Ti
+      maxSize: 3.5Ti
   preservePoolsOnDelete: false
   gateway:
     sslCertificateRef:


### PR DESCRIPTION
the `olly` pool was full again, we are still using it to monitor `kafka stuffs`