### PR TITLE
(*) migrate all ingress resources to use ingressClassName

### DIFF
--- a/chango/prometheus/values.yaml
+++ b/chango/prometheus/values.yaml
@@ -2,9 +2,9 @@
 prometheus:
   ingress:
     enabled: true
+    ingressClassName: nginx
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/backend-protocol: HTTP
       nginx.ingress.kubernetes.io/server-snippet: |
         proxy_ssl_verify off;
@@ -20,9 +20,9 @@ prometheus:
 grafana:
   ingress:
     enabled: true
+    ingressClassName: nginx
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/backend-protocol: HTTP
       nginx.ingress.kubernetes.io/server-snippet: |
         proxy_ssl_verify off;

--- a/chango/rook-ceph/rook-ceph-cluster-values.yaml
+++ b/chango/rook-ceph/rook-ceph-cluster-values.yaml
@@ -192,9 +192,9 @@ cephClusterSpec:
 
 ingress:
   dashboard:
+    ingressClassName: nginx
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/backend-protocol: HTTP
       nginx.ingress.kubernetes.io/server-snippet: |
         proxy_ssl_verify off;

--- a/chango/rook-ceph/s3/ingress.yaml
+++ b/chango/rook-ceph/s3/ingress.yaml
@@ -6,9 +6,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - s3.chango.ls.lsst.org

--- a/fleet/lib/blackbox-exporter/values.yaml
+++ b/fleet/lib/blackbox-exporter/values.yaml
@@ -46,9 +46,9 @@ extraSecretMounts: []
 
 ingress:
   enabled: true
+  className: nginx
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     nginx.ingress.kubernetes.io/server-snippet: |
       proxy_ssl_verify off;

--- a/fleet/lib/keycloak/values.yaml
+++ b/fleet/lib/keycloak/values.yaml
@@ -20,10 +20,10 @@ extraEnvVars:
 
 ingress:
   enabled: true
+  ingressClassName: nginx
   servicePort: http
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
   hostname: keycloak.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org
   tls: true
 

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -6,9 +6,9 @@ prometheus:
       - url: http://mimir-distributed-gateway.mimir:80/api/v1/push
   ingress:
     enabled: true
+    ingressClassName: nginx
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/backend-protocol: HTTP
       nginx.ingress.kubernetes.io/server-snippet: |
         proxy_ssl_verify off;
@@ -31,9 +31,9 @@ alertmanager:
       - alertmanager-templates
   ingress:
     enabled: true
+    ingressClassName: nginx
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/backend-protocol: HTTP
       nginx.ingress.kubernetes.io/server-snippet: |
         proxy_ssl_verify off;
@@ -108,9 +108,9 @@ grafana:
       use_refresh_token: true
   ingress:
     enabled: true
+    ingressClassName: nginx
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/backend-protocol: HTTP
       nginx.ingress.kubernetes.io/server-snippet: |
         proxy_ssl_verify off;

--- a/fleet/lib/kube-prometheus-stack/overlays/pillan/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/overlays/pillan/values.yaml
@@ -109,9 +109,9 @@ prometheus:
 grafana:
   ingress:
     enabled: true
+    ingressClassName: nginx
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/backend-protocol: HTTP
       nginx.ingress.kubernetes.io/server-snippet: |
         proxy_ssl_verify off;

--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -195,10 +195,9 @@ gateway:
   ingress:
     enabled: true
     nameOverride: mimir-nginx
-    classNameName: nginx
+    ingressClassName: nginx
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
       nginx.ingress.kubernetes.io/proxy-body-size: 10m
       nginx.ingress.kubernetes.io/backend-protocol: HTTP

--- a/fleet/lib/nexus/fleet.yaml
+++ b/fleet/lib/nexus/fleet.yaml
@@ -14,9 +14,9 @@ helm:
   values:
     ingress:
       enabled: true
+      ingressClassName: nginx
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
-        kubernetes.io/ingress.class: nginx
         nginx.ingress.kubernetes.io/backend-protocol: HTTP
         nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
       hosts:

--- a/fleet/lib/onepassword-connect/values.yaml
+++ b/fleet/lib/onepassword-connect/values.yaml
@@ -8,9 +8,9 @@ connect:
 
   ingress:
     enabled: true
+    ingressClassName: nginx
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
-      kubernetes.io/ingress.class: nginx
     hosts:
       - host: connect.${ .ClusterLabels.site }.lsst.org
         paths:

--- a/fleet/lib/opensearch-logging/overlays/cp/ingress.yaml
+++ b/fleet/lib/opensearch-logging/overlays/cp/ingress.yaml
@@ -3,12 +3,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/proxy-ssl-verify: "false"
     cert-manager.io/cluster-issuer: letsencrypt
   name: logging-os-api
 spec:
+  ingressClassName: nginx
   rules:
   - host: logging.cp.lsst.org
     http:
@@ -29,13 +29,13 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/use-regex: "true"
   name: logging-os-dashboard
 spec:
+  ingressClassName: nginx
   rules:
   - host: logging.cp.lsst.org
     http:

--- a/fleet/lib/opensearch-logging/overlays/dev/ingress.yaml
+++ b/fleet/lib/opensearch-logging/overlays/dev/ingress.yaml
@@ -3,12 +3,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/proxy-ssl-verify: "false"
     cert-manager.io/cluster-issuer: letsencrypt
   name: logging-os-api
 spec:
+  ingressClassName: nginx
   rules:
   - host: logging.dev.lsst.org
     http:
@@ -29,13 +29,13 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/use-regex: "true"
   name: logging-os-dashboard
 spec:
+  ingressClassName: nginx
   rules:
   - host: logging.dev.lsst.org
     http:

--- a/fleet/lib/opensearch-logging/overlays/ls/ingress.yaml
+++ b/fleet/lib/opensearch-logging/overlays/ls/ingress.yaml
@@ -3,12 +3,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/proxy-ssl-verify: "false"
     cert-manager.io/cluster-issuer: letsencrypt
   name: logging-os-api
 spec:
+  ingressClassName: nginx
   rules:
   - host: logging.ls.lsst.org
     http:
@@ -29,13 +29,13 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/use-regex: "true"
   name: logging-os-dashboard
 spec:
+  ingressClassName: nginx
   rules:
   - host: logging.ls.lsst.org
     http:

--- a/fleet/lib/opensearch-logging/overlays/tu/ingress.yaml
+++ b/fleet/lib/opensearch-logging/overlays/tu/ingress.yaml
@@ -3,12 +3,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/proxy-ssl-verify: "false"
     cert-manager.io/cluster-issuer: letsencrypt
   name: logging-os-api
 spec:
+  ingressClassName: nginx
   rules:
   - host: logging.tu.lsst.org
     http:
@@ -29,13 +29,13 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/use-regex: "true"
   name: logging-os-dashboard
 spec:
+  ingressClassName: nginx
   rules:
   - host: logging.tu.lsst.org
     http:

--- a/fleet/lib/rook-ceph-conf/charts/antu/templates/cephobjectstore-o11y.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/antu/templates/cephobjectstore-o11y.yaml
@@ -39,9 +39,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
     - hosts:
         - &host s3.o11y.antu.ls.lsst.org

--- a/fleet/lib/rook-ceph-conf/charts/chonchon/templates/cephobjectstore-lfa.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/chonchon/templates/cephobjectstore-lfa.yaml
@@ -39,9 +39,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
     - hosts:
         - s3.cp.lsst.org
@@ -65,9 +65,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
     - hosts:
         - s3.chonchon.cp.lsst.org
@@ -91,8 +91,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx-lhn
+    nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx-lhn
   tls:
     - hosts:
         - s3-lhn.cp.lsst.org

--- a/fleet/lib/rook-ceph-conf/charts/chonchon/templates/cephobjectstore-rubintv.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/chonchon/templates/cephobjectstore-rubintv.yaml
@@ -38,9 +38,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - s3.rubintv.cp.lsst.org
@@ -64,9 +64,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - s3.rubintv.chonchon.cp.lsst.org

--- a/fleet/lib/rook-ceph-conf/charts/gaw/templates/cephobjectstore-it.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/gaw/templates/cephobjectstore-it.yaml
@@ -32,9 +32,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - it-s3.ls.lsst.org

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-lfa.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-lfa.yaml
@@ -39,9 +39,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - s3.ls.lsst.org

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-o11y.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-o11y.yaml
@@ -40,9 +40,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - s3.o11y.ls.lsst.org
@@ -66,9 +66,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-dev
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - s3.o11y.dev.lsst.org

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-rubintv.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-rubintv.yaml
@@ -38,9 +38,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - s3.rubintv.ls.lsst.org

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-s3-butler.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-s3-butler.yaml
@@ -38,9 +38,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - s3-butler.ls.lsst.org

--- a/fleet/lib/rook-ceph-conf/charts/kueyen/templates/cephobjectstore-lfa.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/kueyen/templates/cephobjectstore-lfa.yaml
@@ -32,9 +32,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-staging
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - s3.kueyen.dev.lsst.org

--- a/fleet/lib/rook-ceph-conf/charts/lukay/templates/cephobjectstore-it.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/lukay/templates/cephobjectstore-it.yaml
@@ -32,9 +32,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - it-s3.ls.lsst.org

--- a/fleet/lib/rook-ceph-conf/charts/namkueyen/templates/cephobjectstore-lfa.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/namkueyen/templates/cephobjectstore-lfa.yaml
@@ -32,9 +32,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-staging
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - s3.namkueyen.dev.lsst.org

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstore-lfa.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstore-lfa.yaml
@@ -39,9 +39,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - s3.tu.lsst.org

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstore-o11y.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstore-o11y.yaml
@@ -39,9 +39,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - &hostname s3.o11y.pillan.tu.lsst.org

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstore-rubintv.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstore-rubintv.yaml
@@ -38,9 +38,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - s3.rubintv.tu.lsst.org

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstore-lfa.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstore-lfa.yaml
@@ -32,9 +32,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - s3.ruka.dev.lsst.org

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstore-o11y.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstore-o11y.yaml
@@ -39,9 +39,9 @@ metadata:
   namespace: rook-ceph
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/proxy-body-size: 1024m
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - s3.o11y.ruka.dev.lsst.org

--- a/fleet/lib/snmp-exporter/values.yaml
+++ b/fleet/lib/snmp-exporter/values.yaml
@@ -28,9 +28,9 @@ extraArgs:
 
 ingress:
   enabled: true
+  className: nginx
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     nginx.ingress.kubernetes.io/server-snippet: |
       proxy_ssl_verify off;

--- a/luan/kuma/ingress-kuma.yaml
+++ b/luan/kuma/ingress-kuma.yaml
@@ -4,13 +4,13 @@ kind: Ingress
 metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     nginx.ingress.kubernetes.io/server-snippet: |
       proxy_ssl_verify off;
   name: it-kuma-dashboard
   namespace: kuma
 spec:
+  ingressClassName: nginx
   rules:
   - host: it-kuma01.ls.lsst.org
     http:

--- a/manke/keycloak/keycloak.sh
+++ b/manke/keycloak/keycloak.sh
@@ -61,8 +61,8 @@ extraEnvVars:
 ingress:
   enabled: true
   servicePort: http
+  ingressClassName: nginx
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
   hostname: ${KEYCLOAK_INGRESS}
   tls: true

--- a/pillan/keycloak/values.yaml
+++ b/pillan/keycloak/values.yaml
@@ -11,9 +11,9 @@ extraEnvVars:
 
 ingress:
   enabled: true
+  ingressClassName: nginx
   servicePort: http
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/issuer: letsencrypt
   hostname: keycloak.tu.lsst.org
   tls: true

--- a/rancher.cp/rancher/values.yaml
+++ b/rancher.cp/rancher/values.yaml
@@ -1,11 +1,12 @@
 ---
 hostname: rancher.cp.lsst.org
 ingress:
+  enabled: true
+  ingressClassName: nginx
   tls:
     source: secret
   extraAnnotations:
-    "cert-manager.io/cluster-issuer": letsencrypt
-    "kubernetes.io/ingress.class": nginx
+    cert-manager.io/cluster-issuer: letsencrypt
 extraEnv:
   # version strings from https://github.com/rancher/charts/tree/dev-v2.9/charts/fleet
   - name: CATTLE_FLEET_MIN_VERSION

--- a/rancher.dev/rancher/values.yaml
+++ b/rancher.dev/rancher/values.yaml
@@ -1,11 +1,12 @@
 ---
 hostname: rancher.dev.lsst.org
 ingress:
+  enabled: true
+  ingressClassName: nginx
   tls:
     source: secret
   extraAnnotations:
-    "cert-manager.io/cluster-issuer": letsencrypt
-    "kubernetes.io/ingress.class": nginx
+    cert-manager.io/cluster-issuer: letsencrypt
 extraEnv:
   # version strings from https://github.com/rancher/charts/tree/dev-v2.9/charts/fleet
   - name: CATTLE_FLEET_MIN_VERSION

--- a/rancher.ls/rancher/values.yaml
+++ b/rancher.ls/rancher/values.yaml
@@ -1,11 +1,12 @@
 ---
 hostname: rancher.ls.lsst.org
 ingress:
+  enabled: true
+  ingressClassName: nginx
   tls:
     source: secret
   extraAnnotations:
-    "cert-manager.io/cluster-issuer": letsencrypt
-    "kubernetes.io/ingress.class": nginx
+    cert-manager.io/cluster-issuer: letsencrypt
 extraEnv:
   # version strings from https://github.com/rancher/charts/tree/dev-v2.9/charts/fleet
   - name: CATTLE_FLEET_MIN_VERSION

--- a/rancher.tu/rancher/values.yaml
+++ b/rancher.tu/rancher/values.yaml
@@ -1,11 +1,12 @@
 ---
 hostname: rancher.tu.lsst.org
 ingress:
+  enabled: true
+  ingressClassName: nginx
   tls:
     source: secret
   extraAnnotations:
-    "cert-manager.io/cluster-issuer": letsencrypt
-    "kubernetes.io/ingress.class": nginx
+    cert-manager.io/cluster-issuer: letsencrypt
 extraEnv:
   # version strings from https://github.com/rancher/charts/tree/dev-v2.9/charts/fleet
   - name: CATTLE_FLEET_MIN_VERSION

--- a/yagan/keycloak/keycloak.sh
+++ b/yagan/keycloak/keycloak.sh
@@ -60,9 +60,9 @@ extraEnvVars:
 
 ingress:
   enabled: true
+  ingressClassName: nginx
   servicePort: http
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt
   hostname: ${KEYCLOAK_INGRESS}
   tls: true


### PR DESCRIPTION
ruka before this change:
```
 $ k get ing -A
NAMESPACE               NAME                                 CLASS     HOSTS                                 ADDRESS           PORTS     AGE
blackbox-exporter       prometheus-blackbox-exporter         <none>    blackbox-exporter.ruka.dev.lsst.org   139.229.134.150   80, 443   94d
keycloak                keycloak                             <none>    keycloak.ruka.dev.lsst.org            139.229.134.150   80, 443   93d
kube-prometheus-stack   kube-prometheus-stack-alertmanager   <none>    alertmanager.ruka.dev.lsst.org        139.229.134.150   80, 443   94d
kube-prometheus-stack   kube-prometheus-stack-grafana        <none>    grafana.ruka.dev.lsst.org             139.229.134.150   80, 443   94d
kube-prometheus-stack   kube-prometheus-stack-prometheus     <none>    prometheus.ruka.dev.lsst.org          139.229.134.150   80, 443   94d
mimir                   mimir-nginx                          <none>    mimir.ruka.dev.lsst.org               139.229.134.150   80, 443   94d
rook-ceph               rook-ceph-dashboard                  nginx     ceph.ruka.dev.lsst.org                139.229.134.150   80, 443   93d
rook-ceph               rook-ceph-rgw-ingress-o11y           <none>    s3.o11y.ruka.dev.lsst.org             139.229.134.150   80, 443   93d
snmp-exporter           prometheus-snmp-exporter             <none>    snmp-exporter.ruka.dev.lsst.org       139.229.134.150   80, 443   94d
```

ruka after:
```
 $ k get ing -A
NAMESPACE               NAME                                 CLASS   HOSTS                                 ADDRESS           PORTS     AGE
blackbox-exporter       prometheus-blackbox-exporter         nginx   blackbox-exporter.ruka.dev.lsst.org   139.229.134.150   80, 443   94d
keycloak                keycloak                             nginx   keycloak.ruka.dev.lsst.org            139.229.134.150   80, 443   93d
kube-prometheus-stack   kube-prometheus-stack-alertmanager   nginx   alertmanager.ruka.dev.lsst.org        139.229.134.150   80, 443   94d
kube-prometheus-stack   kube-prometheus-stack-grafana        nginx   grafana.ruka.dev.lsst.org             139.229.134.150   80, 443   94d
kube-prometheus-stack   kube-prometheus-stack-prometheus     nginx   prometheus.ruka.dev.lsst.org          139.229.134.150   80, 443   94d
mimir                   mimir-nginx                          nginx   mimir.ruka.dev.lsst.org               139.229.134.150   80, 443   94d
rook-ceph               rook-ceph-dashboard                  nginx   ceph.ruka.dev.lsst.org                139.229.134.150   80, 443   93d
rook-ceph               rook-ceph-rgw-ingress                nginx   s3.ruka.dev.lsst.org                  139.229.134.150   80, 443   93d
rook-ceph               rook-ceph-rgw-ingress-o11y           nginx   s3.o11y.ruka.dev.lsst.org             139.229.134.150   80, 443   93d
snmp-exporter           prometheus-snmp-exporter             nginx   snmp-exporter.ruka.dev.lsst.org       139.229.134.150   80, 443   94d
```