### PR TITLE
(site/tu) bump rke v1.6.5 for k8s v1.30.7-rancher1-1

### DIFF
--- a/rancher.tu/rke/cluster.yml
+++ b/rancher.tu/rke/cluster.yml
@@ -30,6 +30,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.29.8-rancher1-1
+kubernetes_version: v1.30.7-rancher1-1
 ingress:
   provider: none


### PR DESCRIPTION
bump `RKE1 k8s` on `rancher.dev` to `v1.30.7`