### PR TITLE
(site/dev) Add ip to metallb on Kueyen for fluentbit external

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ creds.sh
 secret.yaml
 template.yaml
 **/snmp-generator/mibs
+.DS_Store
+*\ [2-9].sh

--- a/fleet/lib/metallb-conf/overlays/kueyen/ipaddresspool-default.yaml
+++ b/fleet/lib/metallb-conf/overlays/kueyen/ipaddresspool-default.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: metallb-system
 spec:
   addresses:
-    - 139.229.134.88-139.229.134.89
+    - 139.229.134.88-139.229.134.90
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement


### PR DESCRIPTION
Add the IP 139.229.134.90 to metallb.
Add two files to gitignore.