### PR TITLE
(elqui/rook-ceph-conf) set maxBuckets 2 users

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-comcam.yaml
@@ -8,7 +8,7 @@ spec:
   store: lfa
   clusterNamespace: rook-ceph
   quotas:
-    maxBuckets: 1
+    maxBuckets: 2
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-latiss.yaml
@@ -8,8 +8,7 @@ spec:
   store: lfa
   clusterNamespace: rook-ceph
   quotas:
-    maxBuckets: 1
-    maxSize: 100Ti
+    maxBuckets: 2
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-lsstcam.yaml
@@ -8,8 +8,7 @@ spec:
   store: lfa
   clusterNamespace: rook-ceph
   quotas:
-    maxBuckets: 1
-    maxSize: 1Pi
+    maxBuckets: 2
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret


### PR DESCRIPTION
users `comcam`, `latiss` and `lsstcam` need to own their respective `raw` and `butler` buckets, so `maxBuckets` needs to be set to `2`. (all other users are managed by policies.)