### PR TITLE
(fleet/rook/ceph/conf) add mimir s3 account to kueyen

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/kueyen/templates/cephobjectstoreuser-mimir.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/kueyen/templates/cephobjectstoreuser-mimir.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: mimir
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph


### PR DESCRIPTION
Mimir requires a S3 bucket to store the tsdb data.