### PR TITLE
(fleet/cnpg-cluster) bump manke resources

### DIFF
--- a/fleet/lib/cnpg-cluster/overlays/manke/cluster-cnpg-cluster.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/manke/cluster-cnpg-cluster.yaml
@@ -35,8 +35,8 @@ spec:
 
   resources:
     limits:
-      cpu: "1"
-      memory: 1Gi
+      cpu: "2"
+      memory: 4Gi
     requests:
-      cpu: 500m
-      memory: 1Gi
+      cpu: "1"
+      memory: 2Gi


### PR DESCRIPTION
cnpg in manke was getting killed by the OOM, so resources were bump.