### PR TITLE
(fleet/kube-prometheus-stack) Set defaultDashboardsEnabled False on Antu

### DIFF
--- a/fleet/lib/kube-prometheus-stack/overlays/antu/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/overlays/antu/values.yaml
@@ -157,6 +157,7 @@ grafana:
     requests:
       cpu: 4
       memory: 4Gi
+  defaultDashboardsEnabled: false
 
 alertmanager:
   config:


### PR DESCRIPTION
we fixed some dashboards and got duplicates... and by setting this to false, we avoid `Grafana` deploying default dashboards.