### PR TITLE
(fleet/rook-ceph-cluster) set mon_pg_warn_max_object_skew to "0"

### DIFF
--- a/fleet/lib/rook-ceph-cluster/values.yaml
+++ b/fleet/lib/rook-ceph-cluster/values.yaml
@@ -40,6 +40,7 @@ cephClusterSpec:
   cephConfig:
     global:
       rgw_allow_notification_secrets_in_cleartext: "true"
+      mon_pg_warn_max_object_skew: "0"
   dataDirHostPath: /var/lib/rook
   skipUpgradeChecks: false
   continueUpgradeAfterChecksEvenIfNotHealthy: false


### PR DESCRIPTION
Disables this warning:

    cluster:
      id:     c3beb1c0-f8c2-4e36-8131-f53f1afdd3ed
      health: HEALTH_WARN
              1 pools have many more objects per pg than average