### PR TITLE
(kongkong) reduce ceph pool pg allocations by ~1/2

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephnfs-auxtel.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephnfs-auxtel.yaml
@@ -15,7 +15,7 @@ spec:
       nodelete: "true"
       nosizechange: "true"
       pg_autoscale_mode: "off"
-      pg_num: "16"
+      pg_num: "8"
   dataPools:
     - failureDomain: host
       replicated:
@@ -26,7 +26,7 @@ spec:
         nodelete: "true"
         nosizechange: "true"
         pg_autoscale_mode: "off"
-        pg_num: "32"
+        pg_num: "16"
   metadataServer:
     activeCount: 1
     activeStandby: true

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephnfs-comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephnfs-comcam.yaml
@@ -15,7 +15,7 @@ spec:
       nodelete: "true"
       nosizechange: "true"
       pg_autoscale_mode: "off"
-      pg_num: "16"
+      pg_num: "8"
   dataPools:
     - failureDomain: host
       replicated:
@@ -26,7 +26,7 @@ spec:
         nodelete: "true"
         nosizechange: "true"
         pg_autoscale_mode: "off"
-        pg_num: "32"
+        pg_num: "16"
   metadataServer:
     activeCount: 1
     activeStandby: true

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephnfs-lsstdata.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephnfs-lsstdata.yaml
@@ -15,7 +15,7 @@ spec:
       nodelete: "true"
       nosizechange: "true"
       pg_autoscale_mode: "off"
-      pg_num: "16"
+      pg_num: "8"
   dataPools:
     - failureDomain: host
       replicated:
@@ -26,7 +26,7 @@ spec:
         nodelete: "true"
         nosizechange: "true"
         pg_autoscale_mode: "off"
-        pg_num: "32"
+        pg_num: "16"
   metadataServer:
     activeCount: 1
     activeStandby: true

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephnfs-obsenv.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephnfs-obsenv.yaml
@@ -15,7 +15,7 @@ spec:
       nodelete: "true"
       nosizechange: "true"
       pg_autoscale_mode: "off"
-      pg_num: "16"
+      pg_num: "8"
   dataPools:
     - failureDomain: host
       replicated:
@@ -26,7 +26,7 @@ spec:
         nodelete: "true"
         nosizechange: "true"
         pg_autoscale_mode: "off"
-        pg_num: "32"
+        pg_num: "16"
   metadataServer:
     activeCount: 1
     activeStandby: true

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephnfs-project.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephnfs-project.yaml
@@ -15,7 +15,7 @@ spec:
       nodelete: "true"
       nosizechange: "true"
       pg_autoscale_mode: "off"
-      pg_num: "16"
+      pg_num: "8"
   dataPools:
     - failureDomain: host
       replicated:
@@ -26,7 +26,7 @@ spec:
         nodelete: "true"
         nosizechange: "true"
         pg_autoscale_mode: "off"
-        pg_num: "32"
+        pg_num: "16"
   metadataServer:
     activeCount: 1
     activeStandby: true

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephnfs-rsphome.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephnfs-rsphome.yaml
@@ -15,7 +15,7 @@ spec:
       nodelete: "true"
       nosizechange: "true"
       pg_autoscale_mode: "off"
-      pg_num: "16"
+      pg_num: "8"
   dataPools:
     - failureDomain: host
       replicated:
@@ -26,7 +26,7 @@ spec:
         nodelete: "true"
         nosizechange: "true"
         pg_autoscale_mode: "off"
-        pg_num: "32"
+        pg_num: "16"
   metadataServer:
     activeCount: 1
     activeStandby: true

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephnfs-scratch.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephnfs-scratch.yaml
@@ -15,7 +15,7 @@ spec:
       nodelete: "true"
       nosizechange: "true"
       pg_autoscale_mode: "off"
-      pg_num: "16"
+      pg_num: "8"
   dataPools:
     - failureDomain: host
       replicated:
@@ -26,7 +26,7 @@ spec:
         nodelete: "true"
         nosizechange: "true"
         pg_autoscale_mode: "off"
-        pg_num: "32"
+        pg_num: "16"
   metadataServer:
     activeCount: 1
     activeStandby: true

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-lfa.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-lfa.yaml
@@ -152,7 +152,7 @@ spec:
     nodelete: "true"
     nosizechange: "true"
     pg_autoscale_mode: "off"
-    pg_num: "32"
+    pg_num: "8"
   replicated:
     size: 3
 ---
@@ -168,7 +168,7 @@ spec:
     nodelete: "true"
     nosizechange: "true"
     pg_autoscale_mode: "off"
-    pg_num: "32"
+    pg_num: "8"
   replicated:
     size: 3
 ---
@@ -184,7 +184,7 @@ spec:
     nodelete: "true"
     nosizechange: "true"
     pg_autoscale_mode: "off"
-    pg_num: "32"
+    pg_num: "8"
   replicated:
     size: 3
 ---
@@ -200,7 +200,7 @@ spec:
     nodelete: "true"
     nosizechange: "true"
     pg_autoscale_mode: "off"
-    pg_num: "128"
+    pg_num: "32"
   replicated:
     size: 3
 ---
@@ -216,7 +216,7 @@ spec:
     nodelete: "true"
     nosizechange: "true"
     pg_autoscale_mode: "off"
-    pg_num: "128"
+    pg_num: "32"
   replicated:
     size: 3
 ---
@@ -232,7 +232,7 @@ spec:
     nodelete: "true"
     nosizechange: "true"
     pg_autoscale_mode: "off"
-    pg_num: "32"
+    pg_num: "8"
   replicated:
     size: 3
 ---
@@ -265,6 +265,6 @@ spec:
     nosizechange: "true"
     pg_autoscale_mode: "off"
     bulk: "true"
-    pg_num: "512"
+    pg_num: "256"
   replicated:
     size: 3


### PR DESCRIPTION
To resolve this warning:

    cluster:
      id:     8fe980aa-b780-4e3c-b000-e07cbfcf13df
      health: HEALTH_WARN
              too many PGs per OSD (390 > max 250)