### PR TITLE
(fleet/*) rm usage of nginx.ingress.kubernetes.io/server-snippet

### DIFF
--- a/fleet/lib/blackbox-exporter/values.yaml
+++ b/fleet/lib/blackbox-exporter/values.yaml
@@ -90,8 +90,6 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
-    nginx.ingress.kubernetes.io/server-snippet: |
-      proxy_ssl_verify off;
   hosts:
     - host: blackbox-exporter.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org
       paths:

--- a/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/aggregator/values.yaml
@@ -10,8 +10,6 @@ prometheus:
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
       nginx.ingress.kubernetes.io/backend-protocol: HTTP
-      nginx.ingress.kubernetes.io/server-snippet: |
-        proxy_ssl_verify off;
     paths:
       - /
     pathType: Prefix
@@ -35,8 +33,6 @@ alertmanager:
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
       nginx.ingress.kubernetes.io/backend-protocol: HTTP
-      nginx.ingress.kubernetes.io/server-snippet: |
-        proxy_ssl_verify off;
     paths:
       - /
     pathType: Prefix
@@ -112,8 +108,6 @@ grafana:
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt
       nginx.ingress.kubernetes.io/backend-protocol: HTTP
-      nginx.ingress.kubernetes.io/server-snippet: |
-        proxy_ssl_verify off;
     paths:
       - /
     pathType: Prefix

--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -201,8 +201,6 @@ gateway:
       nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
       nginx.ingress.kubernetes.io/proxy-body-size: 10m
       nginx.ingress.kubernetes.io/backend-protocol: HTTP
-      nginx.ingress.kubernetes.io/server-snippet: |
-        proxy_ssl_verify off;
     hosts:
       - host: mimir.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org
         paths:

--- a/fleet/lib/snmp-exporter/values.yaml
+++ b/fleet/lib/snmp-exporter/values.yaml
@@ -32,8 +32,6 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
-    nginx.ingress.kubernetes.io/server-snippet: |
-      proxy_ssl_verify off;
   hosts:
     - snmp-exporter.${ .ClusterName }.${ .ClusterLabels.site }.lsst.org
   tls:


### PR DESCRIPTION
This annotation was being used to disable TLS cert validation but is unnecessary when the backend is explicitly HTTP.