### PR TITLE
(fleet/cnpg-cluster) bump max_logical_replication_workers to 10 on yagan

### DIFF
--- a/fleet/lib/cnpg-cluster/overlays/yagan/cluster-cnpg-cluster.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/yagan/cluster-cnpg-cluster.yaml
@@ -12,6 +12,7 @@ spec:
 
   postgresql:
     parameters:
+      max_logical_replication_workers: "10"
       max_connections: "500"
       shared_buffers: 256MB
       idle_session_timeout: 4h


### PR DESCRIPTION
currently value is 4 (default) and logical replication is taking most of those, but when syncs or rebuilds processes appear, all the slots are empty, this could be very troublesome. EX:

`postgres=# SELECT
  pid,
  usename,
  application_name,
  state         
FROM pg_stat_replication
ORDER BY application_name;
   pid   |      usename      |            application_name             |   state   
---------+-------------------+-----------------------------------------+-----------
     146 | streaming_replica | cnpg-cluster-2                          | streaming
     147 | streaming_replica | cnpg-cluster-3                          | streaming
 4160133 | replicauser       | pg_44323_sync_27775_7434287593974698015 | startup
 3687140 | replicauser       | summit-db-replica-2                     | streaming
 3687141 | replicauser       | usdfsub_exposurelog                     | streaming
 3687106 | replicauser       | usdfsub_narrativelog                    | streaming
 3687142 | replicauser       | usdfsub_nightreport                     | streaming`
 
 during syncs/rebuilds all the slots are used. (`cnpg-cluster-2/3` and `summit-db-replica-2` are `physical`, but the rest 4 logical slots are busy.)
 
 we are setting this value to 10 (which is safe because `max_worker_processes: 32`)

 