### PR TITLE
(konkong & elqui) switch to CephBucketTopic.spec.endpoint.kafka.mechanism

### DIFF
--- a/rke2/elqui/rook-ceph/s3/bucket-rubinobs-raw-comcam-cephbuckettopic.yaml
+++ b/rke2/elqui/rook-ceph/s3/bucket-rubinobs-raw-comcam-cephbuckettopic.yaml
@@ -8,9 +8,9 @@ spec:
   objectStoreName: lfa
   objectStoreNamespace: rook-ceph
   persistent: false
-  opaqueData: "&mechanism=SCRAM-SHA-512"
   endpoint:
     kafka:
       uri: kafka://@sasquatch-summit-kafka-bootstrap.lsst.codes:9094
       ackLevel: broker
       useSSL: true
+      mechanism: SCRAM-SHA-512

--- a/rke2/elqui/rook-ceph/s3/bucket-rubinobs-raw-latiss-cephbuckettopic.yaml
+++ b/rke2/elqui/rook-ceph/s3/bucket-rubinobs-raw-latiss-cephbuckettopic.yaml
@@ -8,9 +8,9 @@ spec:
   objectStoreName: lfa
   objectStoreNamespace: rook-ceph
   persistent: false
-  opaqueData: "&mechanism=SCRAM-SHA-512"
   endpoint:
     kafka:
       uri: kafka://@sasquatch-summit-kafka-bootstrap.lsst.codes:9094
       ackLevel: broker
       useSSL: true
+      mechanism: SCRAM-SHA-512

--- a/rke2/elqui/rook-ceph/s3/bucket-rubinobs-raw-lsstcam-cephbuckettopic.yaml
+++ b/rke2/elqui/rook-ceph/s3/bucket-rubinobs-raw-lsstcam-cephbuckettopic.yaml
@@ -8,9 +8,9 @@ spec:
   objectStoreName: lfa
   objectStoreNamespace: rook-ceph
   persistent: false
-  opaqueData: "&mechanism=SCRAM-SHA-512"
   endpoint:
     kafka:
       uri: kafka://@sasquatch-summit-kafka-bootstrap.lsst.codes:9094
       ackLevel: broker
       useSSL: true
+      mechanism: SCRAM-SHA-512

--- a/rke2/konkong/rook-ceph/s3/bucket-rubinobs-raw-latiss-cephbuckettopic.yaml
+++ b/rke2/konkong/rook-ceph/s3/bucket-rubinobs-raw-latiss-cephbuckettopic.yaml
@@ -8,9 +8,9 @@ spec:
   objectStoreName: lfa
   objectStoreNamespace: rook-ceph
   persistent: false
-  opaqueData: "&mechanism=SCRAM-SHA-512"
   endpoint:
     kafka:
       uri: kafka://@sasquatch-base-kafka-bootstrap.lsst.codes:9094
       ackLevel: broker
       useSSL: true
+      mechanism: SCRAM-SHA-512

--- a/rke2/konkong/rook-ceph/s3/bucket-rubinobs-raw-lsstcam-cephbuckettopic.yaml
+++ b/rke2/konkong/rook-ceph/s3/bucket-rubinobs-raw-lsstcam-cephbuckettopic.yaml
@@ -8,9 +8,9 @@ spec:
   objectStoreName: lfa
   objectStoreNamespace: rook-ceph
   persistent: false
-  opaqueData: "&mechanism=SCRAM-SHA-512"
   endpoint:
     kafka:
       uri: kafka://@sasquatch-base-kafka-bootstrap.lsst.codes:9094
       ackLevel: broker
       useSSL: true
+      mechanism: SCRAM-SHA-512


### PR DESCRIPTION
Rook 1.17.0 will introduce a `mechanism` field in `CephBucketTopic` for controlling the kafka auth mechanism.  This new functionality will add a `mechanism` endpoint arg by default that conflicts with setting the auth mechanism value via the `opaqueData` field.