### PR TITLE
(fleet/cnpg-cluster) boost yagan resources and buffers.

### DIFF
--- a/fleet/lib/cnpg-cluster/overlays/manke/cluster-cnpg-cluster.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/manke/cluster-cnpg-cluster.yaml
@@ -13,8 +13,10 @@ spec:
   postgresql:
     parameters:
       max_connections: "500"
-      shared_buffers: 256MB
-      idle_session_timeout: 4h
+      shared_buffers: 2GB
+      work_mem: 32MB
+      effective_cache_size: 6GB
+      idle_session_timeout: 1h
     pg_hba:
       - host all all 139.229.134.0/23 md5
       - host all all 139.229.136.0/21 md5
@@ -35,8 +37,8 @@ spec:
 
   resources:
     limits:
-      cpu: "2"
-      memory: 4Gi
+      cpu: "4"
+      memory: 8Gi
     requests:
-      cpu: "1"
-      memory: 2Gi
+      cpu: "4"
+      memory: 8Gi

--- a/fleet/lib/cnpg-cluster/overlays/pillan/cluster-cnpg-cluster.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/pillan/cluster-cnpg-cluster.yaml
@@ -13,8 +13,10 @@ spec:
   postgresql:
     parameters:
       max_connections: "500"
-      shared_buffers: 256MB
-      idle_session_timeout: 4h
+      shared_buffers: 512MB
+      work_mem: 16MB
+      effective_cache_size: 1536MB
+      idle_session_timeout: 1h
     pg_hba:
       - host replication postgres all md5
       - host all all 139.229.134.0/23 md5
@@ -36,8 +38,8 @@ spec:
 
   resources:
     limits:
-      cpu: "1"
-      memory: 1Gi
+      cpu: "2"
+      memory: 2Gi
     requests:
-      cpu: 500m
-      memory: 1Gi
+      cpu: "2"
+      memory: 2Gi

--- a/fleet/lib/cnpg-cluster/overlays/ruka/cluster-cnpg-cluster.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/ruka/cluster-cnpg-cluster.yaml
@@ -14,7 +14,9 @@ spec:
     parameters:
       max_connections: "500"
       shared_buffers: 256MB
-      idle_session_timeout: 4h
+      work_mem: 8MB
+      effective_cache_size: 768MB
+      idle_session_timeout: 1h
       max_slot_wal_keep_size: 1GB
     pg_hba:
       - host replication postgres all md5
@@ -42,5 +44,5 @@ spec:
       cpu: "1"
       memory: 1Gi
     requests:
-      cpu: 500m
+      cpu: "1"
       memory: 1Gi

--- a/fleet/lib/cnpg-cluster/overlays/yagan/cluster-cnpg-cluster.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/yagan/cluster-cnpg-cluster.yaml
@@ -14,8 +14,10 @@ spec:
     parameters:
       max_logical_replication_workers: "10"
       max_connections: "500"
-      shared_buffers: 256MB
-      idle_session_timeout: 4h
+      shared_buffers: 4GB
+      work_mem: 64MB
+      effective_cache_size: 12GB
+      idle_session_timeout: 1h
       max_slot_wal_keep_size: 10GB
     pg_hba:
       - host replication replicauser all md5
@@ -38,8 +40,8 @@ spec:
 
   resources:
     limits:
-      cpu: "4"
-      memory: 8Gi
+      cpu: "8"
+      memory: 16Gi
     requests:
-      cpu: "2"
-      memory: 4Gi
+      cpu: "8"
+      memory: 16Gi


### PR DESCRIPTION
-  `shared_buffers: 4GB` recommended 25% of the total RAM (more buffer, less disk writing!)
-  `work_mem: 64MB` bumping from 4MB (more memory to do `JOIN`, `SORT`, etc.)
-  `effective_cache_size: 12GB` (tells the planner it has more memory to assign ~75% of total)
-  `idle_session_timeout: 1h` (reducing the timeout for idle because of poor usage of sockets on Code connecting to DB)