### PR TITLE
(fleet/cnpg-cluster) add more slots and memory to yagan.

### DIFF
--- a/fleet/lib/cnpg-cluster/overlays/yagan/cluster-cnpg-cluster.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/yagan/cluster-cnpg-cluster.yaml
@@ -12,7 +12,8 @@ spec:
 
   postgresql:
     parameters:
-      max_logical_replication_workers: "10"
+      max_worker_processes: "40"
+      max_logical_replication_workers: "20"
       max_connections: "500"
       shared_buffers: 4GB
       work_mem: 64MB
@@ -41,7 +42,7 @@ spec:
   resources:
     limits:
       cpu: "8"
-      memory: 16Gi
+      memory: 32Gi
     requests:
       cpu: "8"
-      memory: 16Gi
+      memory: 32Gi


### PR DESCRIPTION
replication es getting way behind (almost a day according to grafana) so we need more replication slots.
counting for 3 replicas:
- 3 Wal Senders.
- 3 Autovaccum
- 20 logical replication
- ~6 buffer (2 ea)
Total: 32... so i bumped `max_worker_processes: "40"` from `32`

also, from testing last night, `16Gi` of memory was on the edge around `93%` use, so bump to `32Gi` should put us on `~50%`
