### PR TITLE
(fleet/cnpg-cluster) add pgbouncer to cnpg

### DIFF
--- a/fleet/lib/cnpg-cluster/fleet.yaml
+++ b/fleet/lib/cnpg-cluster/fleet.yaml
@@ -1,5 +1,7 @@
 ---
 defaultNamespace: cloudnativepg
+namespaceLabels:
+  lsst.io/discover: "true"
 labels:
   bundle: &name cnpg-cluster
 helm:

--- a/fleet/lib/cnpg-cluster/overlays/manke/pooler-cnpg-cluster-pooler.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/manke/pooler-cnpg-cluster-pooler.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: cnpg-cluster-pooler
+  namespace: cloudnativepg
+spec:
+  cluster:
+    name: cnpg-cluster
+  instances: 3
+  type: rw
+
+  pgbouncer:
+    poolMode: session
+    parameters:
+      max_client_conn: "1000"
+      default_pool_size: "140"
+      reserve_pool_size: "10"
+      reserve_pool_timeout: "5.0"
+      server_lifetime: "3600"
+      server_idle_timeout: "600"
+      idle_transaction_timeout: "60"
+      ignore_startup_parameters: extra_float_digits
+  template:
+    metadata:
+      labels:
+        app: pooler
+        lsst.io/monitor: "true"
+    spec:
+      containers:
+        - name: pgbouncer
+          resources:
+            requests:
+              cpu: "0.1"
+              memory: 100Mi
+            limits:
+              cpu: "0.5"
+              memory: 500Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cnpg-cluster-pooler-rw
+  namespace: cloudnativepg
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 139.229.151.180
+spec:
+  type: LoadBalancer
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: pgbouncer
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    cnpg.io/poolerName: cnpg-cluster-pooler

--- a/fleet/lib/cnpg-cluster/overlays/pillan/pooler-cnpg-cluster-pooler.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/pillan/pooler-cnpg-cluster-pooler.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: cnpg-cluster-pooler
+  namespace: cloudnativepg
+spec:
+  cluster:
+    name: cnpg-cluster
+  instances: 3
+  type: rw
+
+  pgbouncer:
+    poolMode: session
+    parameters:
+      max_client_conn: "1000"
+      default_pool_size: "140"
+      reserve_pool_size: "10"
+      reserve_pool_timeout: "5.0"
+      server_lifetime: "3600"
+      server_idle_timeout: "600"
+      idle_transaction_timeout: "60"
+      ignore_startup_parameters: extra_float_digits
+  template:
+    metadata:
+      labels:
+        app: pooler
+        lsst.io/monitor: "true"
+    spec:
+      containers:
+        - name: pgbouncer
+          resources:
+            requests:
+              cpu: "0.1"
+              memory: 100Mi
+            limits:
+              cpu: "0.5"
+              memory: 500Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cnpg-cluster-pooler-rw
+  namespace: cloudnativepg
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 140.252.147.210
+spec:
+  type: LoadBalancer
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: pgbouncer
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    cnpg.io/poolerName: cnpg-cluster-pooler

--- a/fleet/lib/cnpg-cluster/overlays/ruka/pooler-cnpg-cluster-pooler.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/ruka/pooler-cnpg-cluster-pooler.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: cnpg-cluster-pooler
+  namespace: cloudnativepg
+spec:
+  cluster:
+    name: cnpg-cluster
+  instances: 3
+  type: rw
+
+  pgbouncer:
+    poolMode: session
+    parameters:
+      max_client_conn: "1000"
+      default_pool_size: "140"
+      reserve_pool_size: "10"
+      reserve_pool_timeout: "5.0"
+      server_lifetime: "3600"
+      server_idle_timeout: "600"
+      idle_transaction_timeout: "60"
+      ignore_startup_parameters: extra_float_digits
+  template:
+    metadata:
+      labels:
+        app: pooler
+        lsst.io/monitor: "true"
+    spec:
+      containers:
+        - name: pgbouncer
+          resources:
+            requests:
+              cpu: "0.1"
+              memory: 100Mi
+            limits:
+              cpu: "0.5"
+              memory: 500Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cnpg-cluster-pooler-rw
+  namespace: cloudnativepg
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 139.229.134.199
+spec:
+  type: LoadBalancer
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: pgbouncer
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    cnpg.io/poolerName: cnpg-cluster-pooler

--- a/fleet/lib/cnpg-cluster/overlays/yagan/pooler-cnpg-cluster-pooler.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/yagan/pooler-cnpg-cluster-pooler.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: cnpg-cluster-pooler
+  namespace: cloudnativepg
+spec:
+  cluster:
+    name: cnpg-cluster
+  instances: 3
+  type: rw
+
+  pgbouncer:
+    poolMode: session
+    parameters:
+      max_client_conn: "1000"
+      default_pool_size: "140"
+      reserve_pool_size: "10"
+      reserve_pool_timeout: "5.0"
+      server_lifetime: "3600"
+      server_idle_timeout: "600"
+      idle_transaction_timeout: "60"
+      ignore_startup_parameters: extra_float_digits
+  template:
+    metadata:
+      labels:
+        app: pooler
+        lsst.io/monitor: "true"
+    spec:
+      containers:
+        - name: pgbouncer
+          resources:
+            requests:
+              cpu: "0.1"
+              memory: 100Mi
+            limits:
+              cpu: "0.5"
+              memory: 500Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cnpg-cluster-pooler-rw
+  namespace: cloudnativepg
+  annotations:
+    metallb.universe.tf/loadBalancerIPs: 139.229.180.95
+spec:
+  type: LoadBalancer
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: pgbouncer
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    cnpg.io/poolerName: cnpg-cluster-pooler


### PR DESCRIPTION
This will deploy the pooler in front of the database with another svc, so when ready i just need to update the DNS record to make it work.
140 x 3 pods + (special slots) vs max_connection "500"