### PR TITLE
(site/ls) bump rke to v1.31.7-rancher1-1

### DIFF
--- a/antu/rke/cluster.yml
+++ b/antu/rke/cluster.yml
@@ -45,6 +45,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.30.7-rancher1-1
+kubernetes_version: v1.31.7-rancher1-1
 ingress:
   provider: none

--- a/rancher.ls/rke/cluster.yml
+++ b/rancher.ls/rke/cluster.yml
@@ -30,6 +30,6 @@ network:
   plugin: canal
 ssh_key_path: ~/.ssh/id_rsa
 ignore_docker_version: true
-kubernetes_version: v1.30.7-rancher1-1
+kubernetes_version: v1.31.7-rancher1-1
 ingress:
   provider: none


### PR DESCRIPTION
April 2025 OS upgrades include the following:

RKE Client is bumped to v1.7.6 to support K8S version v1.31.7-rancher-1-1

This version bump will be effective as of tomorrow. 