### PR TITLE
(fleet/cnpg-cluster) reduce manke memory to 32Gi

### DIFF
--- a/fleet/lib/cnpg-cluster/overlays/manke/cluster-cnpg-cluster.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/manke/cluster-cnpg-cluster.yaml
@@ -42,7 +42,7 @@ spec:
   resources:
     limits:
       cpu: "16"
-      memory: 64Gi
+      memory: 32Gi
     requests:
       cpu: "16"
-      memory: 64Gi
+      memory: 32Gi


### PR DESCRIPTION
- 64Gi was too much for Manke, even tho, most of the memory is just "reserved"