### PR TITLE
(ayekan) add lfa cephobjectstore w/ kafka auth from secrets

### DIFF
--- a/fleet/lib/fleet-conf/overlays/dev/gitrepo-ayekan.yaml
+++ b/fleet/lib/fleet-conf/overlays/dev/gitrepo-ayekan.yaml
@@ -12,6 +12,11 @@ spec:
     - fleet/s/dev/c/ayekan/*
   targets:
     - name: ayekan
-      clusterName: ayekan
+      clusterSelector:
+        matchExpressions:
+          - key: management.cattle.io/cluster-display-name
+            operator: In
+            values:
+              - ayekan
   correctDrift:
     enabled: true

--- a/fleet/lib/rook-ceph-cluster/overlays/ayekan/values.yaml
+++ b/fleet/lib/rook-ceph-cluster/overlays/ayekan/values.yaml
@@ -1,7 +1,5 @@
 ---
 cephClusterSpec:
-  network:
-    provider: host
   mon:
     count: 3
   cephConfig:
@@ -46,7 +44,7 @@ cephBlockPools:
         nodelete: "true"
         nosizechange: "true"
         pg_autoscale_mode: "off"
-        pg_num: "128"
+        pg_num: "32"
     storageClass:
       name: rook-ceph-block
       enabled: true

--- a/fleet/lib/rook-ceph-cluster/overlays/ayekan/values.yaml
+++ b/fleet/lib/rook-ceph-cluster/overlays/ayekan/values.yaml
@@ -13,6 +13,13 @@ cephClusterSpec:
       osd_max_pg_per_osd_hard_ratio: "10"
       osd_op_queue: wpq
       osd_scrub_auto_repair: "true"
+    client.rgw.lfa.a:
+      rgw_enable_usage_log: "false"
+      rgw_enable_lc_threads: "false"  # disable object gc
+    client.rgw.lfagc.a:
+      rgw_enable_usage_log: "false"
+      rgw_enable_lc_threads: "true"  # enable object gc
+
   storage:
     useAllNodes: false
     useAllDevices: false

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephbuckettopic-lsst.s3.raw.comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephbuckettopic-lsst.s3.raw.comcam.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBucketTopic
+metadata:
+  name: lsst.s3.raw.comcam
+  namespace: rook-ceph
+spec:
+  objectStoreName: lfa
+  objectStoreNamespace: rook-ceph
+  persistent: false
+  endpoint:
+    kafka:
+      uri: kafka://sasquatch-summit-kafka-bootstrap.lsst.codes:9094
+      ackLevel: broker
+      useSSL: true
+      mechanism: SCRAM-SHA-512
+      UserSecretRef:  # lowercase for rook >= 1.17.2
+        name: &item kafka-bucket-notifications
+        key: username
+      PasswordSecretRef:  # lowercase for rook >= 1.17.2
+        name: *item
+        key: password

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephbuckettopic-lsst.s3.raw.latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephbuckettopic-lsst.s3.raw.latiss.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBucketTopic
+metadata:
+  name: lsst.s3.raw.latiss
+  namespace: rook-ceph
+spec:
+  objectStoreName: lfa
+  objectStoreNamespace: rook-ceph
+  persistent: false
+  endpoint:
+    kafka:
+      uri: kafka://sasquatch-summit-kafka-bootstrap.lsst.codes:9094
+      ackLevel: broker
+      useSSL: true
+      mechanism: SCRAM-SHA-512
+      UserSecretRef:  # lowercase for rook >= 1.17.2
+        name: &item kafka-bucket-notifications
+        key: username
+      PasswordSecretRef:  # lowercase for rook >= 1.17.2
+        name: *item
+        key: password

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephbuckettopic-lsst.s3.raw.lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephbuckettopic-lsst.s3.raw.lsstcam.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBucketTopic
+metadata:
+  name: lsst.s3.raw.lsstcam
+  namespace: rook-ceph
+spec:
+  objectStoreName: lfa
+  objectStoreNamespace: rook-ceph
+  persistent: false
+  endpoint:
+    kafka:
+      uri: kafka://sasquatch-summit-kafka-bootstrap.lsst.codes:9094
+      ackLevel: broker
+      useSSL: true
+      mechanism: SCRAM-SHA-512
+      UserSecretRef:  # lowercase for rook >= 1.17.2
+        name: &item kafka-bucket-notifications
+        key: username
+      PasswordSecretRef:  # lowercase for rook >= 1.17.2
+        name: *item
+        key: password

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstore-lfa.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstore-lfa.yaml
@@ -1,0 +1,229 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectRealm
+metadata:
+  name: lfa
+  namespace: rook-ceph
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectZoneGroup
+metadata:
+  name: lfa
+  namespace: rook-ceph
+spec:
+  realm: lfa
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectZone
+metadata:
+  name: lfa
+  namespace: rook-ceph
+spec:
+  zoneGroup: lfa
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStore
+metadata:
+  name: lfa
+  namespace: rook-ceph
+spec:
+  preservePoolsOnDelete: true
+  gateway:
+    port: 80
+    instances: 3
+    resources:
+      limits:
+        cpu: "16"
+        memory: 32Gi
+      requests:
+        cpu: "1"
+        memory: 8Gi
+  zone:
+    name: lfa
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStore
+metadata:
+  name: lfagc  # gc only
+  namespace: rook-ceph
+spec:
+  preservePoolsOnDelete: true
+  gateway:
+    port: 80
+    instances: 3
+    resources:
+      limits:
+        cpu: "16"
+        memory: 32Gi
+      requests:
+        cpu: "1"
+        memory: 8Gi
+  zone:
+    name: lfa
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: rook-ceph-rgw-lfa
+  namespace: rook-ceph
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    nginx.ingress.kubernetes.io/proxy-body-size: 1024m
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - &host s3.ayekan.dev.lsst.org
+      secretName: rook-ceph-rgw-lfa-ingress-tls
+  rules:
+    - host: *host
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: rook-ceph-rgw-lfa
+                port:
+                  number: 80
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: rgw.root
+  namespace: rook-ceph
+spec:
+  application: rgw
+  failureDomain: host
+  name: .rgw.root
+  parameters:
+    nodelete: "true"
+    nosizechange: "true"
+    pg_autoscale_mode: "off"
+    pg_num: "16"
+  replicated:
+    size: 3
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: lfa.rgw.control
+  namespace: rook-ceph
+spec:
+  application: rgw
+  failureDomain: host
+  parameters:
+    nodelete: "true"
+    nosizechange: "true"
+    pg_autoscale_mode: "off"
+    pg_num: "16"
+  replicated:
+    size: 3
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: lfa.rgw.meta
+  namespace: rook-ceph
+spec:
+  application: rgw
+  failureDomain: host
+  parameters:
+    nodelete: "true"
+    nosizechange: "true"
+    pg_autoscale_mode: "off"
+    pg_num: "16"
+  replicated:
+    size: 3
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: lfa.rgw.log
+  namespace: rook-ceph
+spec:
+  application: rgw
+  failureDomain: host
+  parameters:
+    nodelete: "true"
+    nosizechange: "true"
+    pg_autoscale_mode: "off"
+    pg_num: "16"
+  replicated:
+    size: 3
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: lfa.rgw.buckets.index
+  namespace: rook-ceph
+spec:
+  application: rgw
+  failureDomain: host
+  parameters:
+    nodelete: "true"
+    nosizechange: "true"
+    pg_autoscale_mode: "off"
+    pg_num: "32"
+  replicated:
+    size: 3
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: lfa.rgw.buckets.non-ec
+  namespace: rook-ceph
+spec:
+  application: rgw
+  failureDomain: host
+  parameters:
+    nodelete: "true"
+    nosizechange: "true"
+    pg_autoscale_mode: "off"
+    pg_num: "16"
+  replicated:
+    size: 3
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: lfa.rgw.otp
+  namespace: rook-ceph
+spec:
+  application: rgw
+  failureDomain: host
+  parameters:
+    nodelete: "true"
+    nosizechange: "true"
+    pg_autoscale_mode: "off"
+    pg_num: "1"
+  replicated:
+    size: 3
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: lfa.rgw.buckets.data
+  namespace: rook-ceph
+spec:
+  application: rgw
+  erasureCoded:
+    dataChunks: 2
+    codingChunks: 1
+  failureDomain: host
+  parameters:
+    nodelete: "true"
+    nosizechange: "true"
+    pg_autoscale_mode: "off"
+    bulk: "true"
+    pg_num: "256"
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: lfa
+provisioner: rook-ceph.ceph.rook.io/bucket
+parameters:
+  objectStoreName: lfa
+  objectStoreNamespace: rook-ceph
+reclaimPolicy: Retain

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-butler.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-butler.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: butler
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 2
+    maxSize: 2Pi

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-calib.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-calib.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: calib
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-comcam.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: comcam
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 2

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-extended-ceph-exporter.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-extended-ceph-exporter.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: extended-ceph-exporter
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  displayName: extended-ceph-exporter
+  capabilities:
+    buckets: read
+    users: read
+    usage: read
+    metadata: read
+    zone: read

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-latiss.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: latiss
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 2

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-lsstcam.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: lsstcam
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 2

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-oods-comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-oods-comcam.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: oods-comcam
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-oods-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-oods-latiss.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: oods-latiss
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-oods-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-oods-lsstcam.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: oods-lsstcam
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-rubintv.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-rubintv.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: rubintv
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 1

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-s3lhn.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-s3lhn.yaml
@@ -1,0 +1,13 @@
+---
+# XXX this user should be read-only. E.g.:
+# radosgw-admin user create --uid=s3lhn --display-name=s3lhn --max-buckets 0 --op-mask=read ...
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: s3lhn
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 0

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-saluser.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstoreuser-saluser.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: saluser
+  namespace: rook-ceph
+spec:
+  store: lfa
+  clusterNamespace: rook-ceph
+  quotas:
+    maxBuckets: 1

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/externalsecrets-kafka-bucket-notifications.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/externalsecrets-kafka-bucket-notifications.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: kafka-bucket-notifications
+  namespace: rook-ceph
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  data:
+    - secretKey: username
+      remoteRef:
+        key: &item kafka-bucket-notifications
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: *item
+        property: password

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-butler-comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-butler-comcam.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: rubinobs-butler-comcam
+  namespace: rook-ceph
+spec:
+  bucketName: rubinobs-butler-comcam
+  storageClassName: lfa
+  additionalConfig:
+    bucketOwner: comcam
+    bucketMaxSize: 20Ti
+    bucketPolicy: |
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Effect": "Allow",
+                  "Principal": {
+                      "AWS": "arn:aws:iam:::user/butler"
+                  },
+                  "Action": [
+                      "s3:GetObject",
+                      "s3:PutObject",
+                      "s3:DeleteObject",
+                      "s3:ListBucket",
+                      "s3:GetBucketLocation"
+                  ],
+                  "Resource": [
+                      "arn:aws:s3:::rubinobs-butler-comcam",
+                      "arn:aws:s3:::rubinobs-butler-comcam/*"
+                  ]
+              },
+              {
+                  "Effect": "Allow",
+                  "Principal": {
+                      "AWS": "arn:aws:iam:::user/oods-comcam"
+                  },
+                  "Action": [
+                      "s3:GetObject",
+                      "s3:PutObject",
+                      "s3:DeleteObject",
+                      "s3:ListBucket",
+                      "s3:GetBucketLocation"
+                  ],
+                  "Resource": [
+                      "arn:aws:s3:::rubinobs-butler-comcam",
+                      "arn:aws:s3:::rubinobs-butler-comcam/*"
+                  ]
+              }
+          ]
+      }
+    bucketLifecycle: |
+      {
+        "Rules": [
+          {
+            "ID": "AbortIncompleteMultipartUploads",
+            "Status": "Enabled",
+            "Prefix": "",
+            "AbortIncompleteMultipartUpload": {
+              "DaysAfterInitiation": 1
+            }
+          },
+          {
+            "ID": "ExpireAfter30Days",
+            "Status": "Enabled",
+            "Prefix": "",
+            "Expiration": {
+              "Days": 90
+            }
+          }
+        ]
+      }

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-butler-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-butler-latiss.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: rubinobs-butler-latiss
+  namespace: rook-ceph
+spec:
+  bucketName: rubinobs-butler-latiss
+  storageClassName: lfa
+  additionalConfig:
+    bucketOwner: latiss
+    bucketMaxSize: 10Ti
+    bucketPolicy: |
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Effect": "Allow",
+                  "Principal": {
+                      "AWS": "arn:aws:iam:::user/butler"
+                  },
+                  "Action": [
+                      "s3:GetObject",
+                      "s3:PutObject",
+                      "s3:DeleteObject",
+                      "s3:ListBucket",
+                      "s3:GetBucketLocation"
+                  ],
+                  "Resource": [
+                      "arn:aws:s3:::rubinobs-butler-latiss",
+                      "arn:aws:s3:::rubinobs-butler-latiss/*"
+                  ]
+              },
+              {
+                  "Effect": "Allow",
+                  "Principal": {
+                      "AWS": "arn:aws:iam:::user/oods-latiss"
+                  },
+                  "Action": [
+                      "s3:GetObject",
+                      "s3:PutObject",
+                      "s3:DeleteObject",
+                      "s3:ListBucket",
+                      "s3:GetBucketLocation"
+                  ],
+                  "Resource": [
+                      "arn:aws:s3:::rubinobs-butler-latiss",
+                      "arn:aws:s3:::rubinobs-butler-latiss/*"
+                  ]
+              }
+          ]
+      }
+    bucketLifecycle: |
+      {
+        "Rules": [
+          {
+            "ID": "AbortIncompleteMultipartUploads",
+            "Status": "Enabled",
+            "Prefix": "",
+            "AbortIncompleteMultipartUpload": {
+              "DaysAfterInitiation": 1
+            }
+          },
+          {
+            "ID": "ExpireAfter30Days",
+            "Status": "Enabled",
+            "Prefix": "",
+            "Expiration": {
+              "Days": 90
+            }
+          }
+        ]
+      }

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-butler-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-butler-lsstcam.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: rubinobs-butler-lsstcam
+  namespace: rook-ceph
+spec:
+  bucketName: rubinobs-butler-lsstcam
+  storageClassName: lfa
+  additionalConfig:
+    bucketOwner: lsstcam
+    bucketMaxSize: 2.5Pi
+    bucketPolicy: |
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Effect": "Allow",
+                  "Principal": {
+                      "AWS": "arn:aws:iam:::user/butler"
+                  },
+                  "Action": [
+                      "s3:GetObject",
+                      "s3:PutObject",
+                      "s3:DeleteObject",
+                      "s3:ListBucket",
+                      "s3:GetBucketLocation"
+                  ],
+                  "Resource": [
+                      "arn:aws:s3:::rubinobs-butler-lsstcam",
+                      "arn:aws:s3:::rubinobs-butler-lsstcam/*"
+                  ]
+              },
+              {
+                  "Effect": "Allow",
+                  "Principal": {
+                      "AWS": "arn:aws:iam:::user/oods-lsstcam"
+                  },
+                  "Action": [
+                      "s3:GetObject",
+                      "s3:PutObject",
+                      "s3:DeleteObject",
+                      "s3:ListBucket",
+                      "s3:GetBucketLocation"
+                  ],
+                  "Resource": [
+                      "arn:aws:s3:::rubinobs-butler-lsstcam",
+                      "arn:aws:s3:::rubinobs-butler-lsstcam/*"
+                  ]
+              }
+          ]
+      }
+
+    bucketLifecycle: |
+      {
+        "Rules": [
+          {
+            "ID": "AbortIncompleteMultipartUploads",
+            "Status": "Enabled",
+            "Prefix": "",
+            "AbortIncompleteMultipartUpload": {
+              "DaysAfterInitiation": 1
+            }
+          },
+          {
+            "ID": "ExpireAfter30Days",
+            "Status": "Enabled",
+            "Prefix": "",
+            "Expiration": {
+              "Days": 90
+            }
+          }
+        ]
+      }

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-calibrations.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-calibrations.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: rubinobs-calibrations
+  namespace: rook-ceph
+spec:
+  bucketName: rubinobs-calibrations
+  storageClassName: lfa
+  additionalConfig:
+    bucketOwner: calib
+    bucketMaxSize: 10Ti
+    bucketPolicy: |
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Effect": "Allow",
+                  "Principal": {
+                      "AWS": "arn:aws:iam:::user/butler"
+                  },
+                  "Action": [
+                      "s3:GetObject",
+                      "s3:ListBucket",
+                      "s3:GetBucketLocation"
+                  ],
+                  "Resource": [
+                      "arn:aws:s3:::rubinobs-calibrations",
+                      "arn:aws:s3:::rubinobs-calibrations/*"
+                  ]
+              },
+              {
+                  "Effect": "Allow",
+                  "Principal": {
+                      "AWS": "arn:aws:iam:::user/oods-latiss"
+                  },
+                  "Action": [
+                      "s3:GetObject",
+                      "s3:ListBucket",
+                      "s3:GetBucketLocation"
+                  ],
+                  "Resource": [
+                      "arn:aws:s3:::rubinobs-calibrations",
+                      "arn:aws:s3:::rubinobs-calibrations/*"
+                  ]
+              },
+              {
+                  "Effect": "Allow",
+                  "Principal": {
+                      "AWS": "arn:aws:iam:::user/oods-comcam"
+                  },
+                  "Action": [
+                      "s3:GetObject",
+                      "s3:ListBucket",
+                      "s3:GetBucketLocation"
+                  ],
+                  "Resource": [
+                      "arn:aws:s3:::rubinobs-calibrations",
+                      "arn:aws:s3:::rubinobs-calibrations/*"
+                  ]
+              },
+              {
+                  "Effect": "Allow",
+                  "Principal": {
+                      "AWS": "arn:aws:iam:::user/oods-lsstcam"
+                  },
+                  "Action": [
+                      "s3:GetObject",
+                      "s3:ListBucket",
+                      "s3:GetBucketLocation"
+                  ],
+                  "Resource": [
+                      "arn:aws:s3:::rubinobs-calibrations",
+                      "arn:aws:s3:::rubinobs-calibrations/*"
+                  ]
+              }
+          ]
+      }
+    bucketLifecycle: |
+      {
+        "Rules": [
+          {
+            "ID": "AbortIncompleteMultipartUploads",
+            "Status": "Enabled",
+            "Prefix": "",
+            "AbortIncompleteMultipartUpload": {
+              "DaysAfterInitiation": 1
+            }
+          }
+        ]
+      }

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-raw-comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-raw-comcam.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: rubinobs-raw-comcam
+  namespace: rook-ceph
+  labels:
+    bucket-notification-lsst.s3.raw.comcam: lsst.s3.raw.comcam
+spec:
+  bucketName: rubinobs-raw-comcam
+  storageClassName: lfa
+  additionalConfig:
+    bucketOwner: comcam
+    bucketMaxSize: 5Ti
+    bucketPolicy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam:::user/butler"
+            },
+            "Action": [
+              "s3:GetObject",
+              "s3:ListBucket",
+              "s3:GetBucketLocation"
+            ],
+            "Resource": [
+              "arn:aws:s3:::rubinobs-raw-comcam",
+              "arn:aws:s3:::rubinobs-raw-comcam/*"
+            ]
+          },
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam:::user/oods-comcam"
+            },
+            "Action": [
+              "s3:GetObject",
+              "s3:ListBucket",
+              "s3:DeleteObject",
+              "s3:GetBucketLocation",
+              "s3:PutObject"
+            ],
+            "Resource": [
+              "arn:aws:s3:::rubinobs-raw-comcam",
+              "arn:aws:s3:::rubinobs-raw-comcam/*"
+            ]
+          }
+        ]
+      }
+    bucketLifecycle: |
+      {
+        "Rules": [
+          {
+            "ID": "AbortIncompleteMultipartUploads",
+            "Status": "Enabled",
+            "Prefix": "",
+            "AbortIncompleteMultipartUpload": {
+              "DaysAfterInitiation": 1
+            }
+          },
+          {
+            "ID": "ExpireAfter30Days",
+            "Status": "Enabled",
+            "Prefix": "",
+            "Expiration": {
+              "Days": 90
+            }
+          }
+        ]
+      }
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBucketNotification
+metadata:
+  name: lsst.s3.raw.comcam
+  namespace: rook-ceph
+spec:
+  topic: lsst.s3.raw.comcam
+  events:
+    - s3:ObjectCreated:*

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-raw-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-raw-latiss.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: rubinobs-raw-latiss
+  namespace: rook-ceph
+  labels:
+    bucket-notification-lsst.s3.raw.latiss: lsst.s3.raw.latiss
+spec:
+  bucketName: rubinobs-raw-latiss
+  storageClassName: lfa
+  additionalConfig:
+    bucketOwner: latiss
+    bucketMaxSize: 1Ti
+    bucketPolicy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam:::user/butler"
+            },
+            "Action": [
+              "s3:GetObject",
+              "s3:ListBucket",
+              "s3:GetBucketLocation"
+            ],
+            "Resource": [
+              "arn:aws:s3:::rubinobs-raw-latiss",
+              "arn:aws:s3:::rubinobs-raw-latiss/*"
+            ]
+          },
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam:::user/oods-latiss"
+            },
+            "Action": [
+              "s3:GetObject",
+              "s3:ListBucket",
+              "s3:DeleteObject",
+              "s3:GetBucketLocation",
+              "s3:PutObject"
+            ],
+            "Resource": [
+              "arn:aws:s3:::rubinobs-raw-latiss",
+              "arn:aws:s3:::rubinobs-raw-latiss/*"
+            ]
+          }
+        ]
+      }
+    bucketLifecycle: |
+      {
+        "Rules": [
+          {
+            "ID": "AbortIncompleteMultipartUploads",
+            "Status": "Enabled",
+            "Prefix": "",
+            "AbortIncompleteMultipartUpload": {
+              "DaysAfterInitiation": 1
+            }
+          },
+          {
+            "ID": "ExpireAfter30Days",
+            "Status": "Enabled",
+            "Prefix": "",
+            "Expiration": {
+              "Days": 90
+            }
+          }
+        ]
+      }
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBucketNotification
+metadata:
+  name: lsst.s3.raw.latiss
+  namespace: rook-ceph
+spec:
+  topic: lsst.s3.raw.latiss
+  events:
+    - s3:ObjectCreated:*

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-raw-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-raw-lsstcam.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: rubinobs-raw-lsstcam
+  namespace: rook-ceph
+  labels:
+    bucket-notification-lsst.s3.raw.lsstcam: lsst.s3.raw.lsstcam
+spec:
+  bucketName: rubinobs-raw-lsstcam
+  storageClassName: lfa
+  additionalConfig:
+    bucketOwner: lsstcam
+    bucketMaxSize: 200Ti
+    bucketPolicy: |
+      {
+          "Version": "2012-10-17",
+          "Statement": [
+              {
+                  "Effect": "Allow",
+                  "Principal": {
+                      "AWS": "arn:aws:iam:::user/butler"
+                  },
+                  "Action": [
+                      "s3:GetObject",
+                      "s3:ListBucket",
+                      "s3:GetBucketLocation"
+                  ],
+                  "Resource": [
+                      "arn:aws:s3:::rubinobs-raw-lsstcam",
+                      "arn:aws:s3:::rubinobs-raw-lsstcam/*"
+                  ]
+              },
+              {
+                  "Effect": "Allow",
+                  "Principal": {
+                      "AWS": "arn:aws:iam:::user/oods-lsstcam"
+                  },
+                  "Action": [
+                      "s3:GetObject",
+                      "s3:PutObject",
+                      "s3:DeleteObject",
+                      "s3:ListBucket",
+                      "s3:GetBucketLocation"
+                  ],
+                  "Resource": [
+                      "arn:aws:s3:::rubinobs-raw-lsstcam",
+                      "arn:aws:s3:::rubinobs-raw-lsstcam/*"
+                  ]
+              }
+          ]
+      }
+    bucketLifecycle: |
+      {
+        "Rules": [
+          {
+            "ID": "AbortIncompleteMultipartUploads",
+            "Status": "Enabled",
+            "Prefix": "",
+            "AbortIncompleteMultipartUpload": {
+              "DaysAfterInitiation": 1
+            }
+          },
+          {
+            "ID": "ExpireAfter30Days",
+            "Status": "Enabled",
+            "Prefix": "",
+            "Expiration": {
+              "Days": 90
+            }
+          }
+        ]
+      }
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBucketNotification
+metadata:
+  name: lsst.s3.raw.lsstcam
+  namespace: rook-ceph
+spec:
+  topic: lsst.s3.raw.lsstcam
+  events:
+    - s3:ObjectCreated:*

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubintv.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubintv.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: rubintv
+  namespace: rook-ceph
+spec:
+  bucketName: rubintv
+  storageClassName: lfa
+  additionalConfig:
+    bucketOwner: rubintv
+    bucketMaxSize: 10Ti
+    bucketLifecycle: |
+      {
+        "Rules": [
+          {
+            "ID": "AbortIncompleteMultipartUploads",
+            "Status": "Enabled",
+            "Prefix": "",
+            "AbortIncompleteMultipartUpload": {
+              "DaysAfterInitiation": 1
+            }
+          }
+        ]
+      }


### PR DESCRIPTION
These changesets were split out of https://github.com/lsst-it/k8s-cookbook/pull/869, which should stay on hold until Rook 1.17.2 is released,  which will include the important fix https://github.com/rook/rook/pull/15816.

As other Rook configuration dev work requires a object store on ayekan, it makes sense to merge this now.