### PR TITLE
(fleet/kube-prometheus-stack) lower request/limits on rancher clusters

### DIFF
--- a/fleet/lib/kube-prometheus-stack/fleet.yaml
+++ b/fleet/lib/kube-prometheus-stack/fleet.yaml
@@ -83,9 +83,10 @@ targetCustomizations:
         - key: management.cattle.io/cluster-display-name
           operator: In
           values:
-            - konkong
             - local
     helm:
+      valuesFiles:
+        - low-resource/values.yaml
       values:
         prometheus:
           prometheusSpec:
@@ -121,6 +122,8 @@ targetCustomizations:
           values:
             - local
     helm:
+      valuesFiles:
+        - low-resource/values.yaml
       values:
         prometheus:
           prometheusSpec:

--- a/fleet/lib/kube-prometheus-stack/low-resource/values.yaml
+++ b/fleet/lib/kube-prometheus-stack/low-resource/values.yaml
@@ -1,0 +1,10 @@
+---
+prometheus:
+  prometheusSpec:
+    resources:
+      limits:
+        cpu: 500m
+        memory: 2Gi
+      requests:
+        cpu: 100m
+        memory: 1Gi


### PR DESCRIPTION
- this lowers the request/limits on kube-prometheus-stack for the rancher clusters.
*this cannot go without merging first* https://github.com/lsst-it/k8s-cookbook/pull/912