### PR TITLE
(fleet/lib/ccs-influxdb/values.yaml) bump PVC size

### DIFF
--- a/fleet/lib/ccs-influxdb/values.yaml
+++ b/fleet/lib/ccs-influxdb/values.yaml
@@ -12,7 +12,7 @@ ingress:
 persistence:
   enabled: true
   accessMode: ReadWriteOnce
-  size: 8Gi
+  size: 12Gi
 
 influxdb:
   authEnabled: true


### PR DESCRIPTION
This solves the issue of the PVC being filled, but it is a temporary solution. Max Turri will need to find the process that is filling the PVC (as seen on the Grafana Screenshot).
![image (5)](https://github.com/user-attachments/assets/7dff9db3-149f-4963-b198-db4475c07068)
