### PR TITLE
(*) fix ownership of rubinobs-butler-* buckets

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-butler-comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-butler-comcam.yaml
@@ -2,13 +2,13 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-butler-comcam
+  name: &name rubinobs-butler-comcam
   namespace: rook-ceph
 spec:
-  bucketName: rubinobs-butler-comcam
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
-    bucketOwner: comcam
+    bucketOwner: butler
     bucketMaxSize: 20Ti
     bucketPolicy: |
       {

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-butler-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-butler-latiss.yaml
@@ -2,13 +2,13 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-butler-latiss
+  name: &name rubinobs-butler-latiss
   namespace: rook-ceph
 spec:
-  bucketName: rubinobs-butler-latiss
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
-    bucketOwner: latiss
+    bucketOwner: butler
     bucketMaxSize: 10Ti
     bucketPolicy: |
       {

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-calibrations.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-calibrations.yaml
@@ -2,10 +2,10 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-calibrations
+  name: &name rubinobs-calibrations
   namespace: rook-ceph
 spec:
-  bucketName: rubinobs-calibrations
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
     bucketOwner: calib

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-lfa-cp.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-lfa-cp.yaml
@@ -2,55 +2,46 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: &name rubinobs-butler-lsstcam
+  name: &name rubinobs-lfa-cp
   namespace: rook-ceph
 spec:
   bucketName: *name
   storageClassName: lfa
   additionalConfig:
-    bucketOwner: butler
-    bucketMaxSize: 2.5Pi
+    bucketOwner: saluser
+    bucketMaxSize: 10Ti
     bucketPolicy: |
       {
           "Version": "2012-10-17",
           "Statement": [
               {
+                  "Sid": "AllowReadAccess",
                   "Effect": "Allow",
                   "Principal": {
-                      "AWS": "arn:aws:iam:::user/butler"
+                      "AWS": "arn:aws:iam:::user/s3lhn"
                   },
                   "Action": [
-                      "s3:GetObject",
-                      "s3:PutObject",
-                      "s3:DeleteObject",
                       "s3:ListBucket",
-                      "s3:GetBucketLocation"
+                      "s3:GetObject",
+                      "s3:GetObjectVersion"
                   ],
                   "Resource": [
-                      "arn:aws:s3:::rubinobs-butler-lsstcam",
-                      "arn:aws:s3:::rubinobs-butler-lsstcam/*"
+                      "arn:aws:s3:::rubinobs-lfa-cp",
+                      "arn:aws:s3:::rubinobs-lfa-cp/*"
                   ]
               },
               {
+                  "Sid": "PublicRead",
                   "Effect": "Allow",
-                  "Principal": {
-                      "AWS": "arn:aws:iam:::user/oods-lsstcam"
-                  },
+                  "Principal": "*",
                   "Action": [
                       "s3:GetObject",
-                      "s3:PutObject",
-                      "s3:DeleteObject",
-                      "s3:ListBucket",
-                      "s3:GetBucketLocation"
+                      "s3:GetObjectVersion"
                   ],
-                  "Resource": [
-                      "arn:aws:s3:::rubinobs-butler-lsstcam",
-                      "arn:aws:s3:::rubinobs-butler-lsstcam/*"
-                  ]
+                  "Resource": ["arn:aws:s3:::*"]
               }
           ]
       }
-
     bucketLifecycle: |
       {
         "Rules": [
@@ -67,7 +58,7 @@ spec:
             "Status": "Enabled",
             "Prefix": "",
             "Expiration": {
-              "Days": 90
+              "Days": 30
             }
           }
         ]

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-raw-comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-raw-comcam.yaml
@@ -2,12 +2,12 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-raw-comcam
+  name: &name rubinobs-raw-comcam
   namespace: rook-ceph
   labels:
     bucket-notification-lsst.s3.raw.comcam: lsst.s3.raw.comcam
 spec:
-  bucketName: rubinobs-raw-comcam
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
     bucketOwner: comcam
@@ -62,7 +62,7 @@ spec:
             }
           },
           {
-            "ID": "ExpireAfter30Days",
+            "ID": "ExpireAfter90Days",
             "Status": "Enabled",
             "Prefix": "",
             "Expiration": {

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-raw-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-raw-latiss.yaml
@@ -2,12 +2,12 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-raw-latiss
+  name: &name rubinobs-raw-latiss
   namespace: rook-ceph
   labels:
     bucket-notification-lsst.s3.raw.latiss: lsst.s3.raw.latiss
 spec:
-  bucketName: rubinobs-raw-latiss
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
     bucketOwner: latiss
@@ -62,7 +62,7 @@ spec:
             }
           },
           {
-            "ID": "ExpireAfter30Days",
+            "ID": "ExpireAfter90Days",
             "Status": "Enabled",
             "Prefix": "",
             "Expiration": {

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-raw-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubinobs-raw-lsstcam.yaml
@@ -2,12 +2,12 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-raw-lsstcam
+  name: &name rubinobs-raw-lsstcam
   namespace: rook-ceph
   labels:
     bucket-notification-lsst.s3.raw.lsstcam: lsst.s3.raw.lsstcam
 spec:
-  bucketName: rubinobs-raw-lsstcam
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
     bucketOwner: lsstcam
@@ -62,7 +62,7 @@ spec:
             }
           },
           {
-            "ID": "ExpireAfter30Days",
+            "ID": "ExpireAfter90Days",
             "Status": "Enabled",
             "Prefix": "",
             "Expiration": {

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubintv.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/obc-rubintv.yaml
@@ -2,10 +2,10 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubintv
+  name: &name rubintv
   namespace: rook-ceph
 spec:
-  bucketName: rubintv
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
     bucketOwner: rubintv

--- a/fleet/lib/rook-ceph-conf/charts/ayekan/values.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/values.yaml
@@ -4,11 +4,12 @@ users:
     spec:
       store: lfa
       quotas:
-        maxBuckets: 2
-        maxSize: 2Pi
+        maxBuckets: 3
   - name: calib
     spec:
       store: lfa
+      quotas:
+        maxBuckets: 1
   - name: comcam
     spec:
       store: lfa
@@ -27,12 +28,18 @@ users:
   - name: oods-comcam
     spec:
       store: lfa
+      quotas:
+        maxBuckets: 0
   - name: oods-latiss
     spec:
       store: lfa
+      quotas:
+        maxBuckets: 0
   - name: oods-lsstcam
     spec:
       store: lfa
+      quotas:
+        maxBuckets: 0
   - name: rubintv
     spec:
       store: lfa

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-extended-ceph-exporter.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstoreuser-extended-ceph-exporter.yaml
@@ -10,7 +10,7 @@ spec:
   displayName: extended-ceph-exporter
   capabilities:
     buckets: read
-    users: read
-    usage: read
     metadata: read
+    usage: read
+    users: read
     zone: read

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubinobs-butler-comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubinobs-butler-comcam.yaml
@@ -2,13 +2,13 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-butler-comcam
+  name: &name rubinobs-butler-comcam
   namespace: rook-ceph
 spec:
-  bucketName: rubinobs-butler-comcam
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
-    bucketOwner: comcam
+    bucketOwner: butler
     bucketMaxSize: 20Ti
     bucketPolicy: |
       {
@@ -59,14 +59,6 @@ spec:
             "Prefix": "",
             "AbortIncompleteMultipartUpload": {
               "DaysAfterInitiation": 1
-            }
-          },
-          {
-            "ID": "ExpireAfter30Days",
-            "Status": "Enabled",
-            "Prefix": "",
-            "Expiration": {
-              "Days": 90
             }
           }
         ]

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubinobs-butler-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubinobs-butler-latiss.yaml
@@ -2,13 +2,13 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-butler-latiss
+  name: &name rubinobs-butler-latiss
   namespace: rook-ceph
 spec:
-  bucketName: rubinobs-butler-latiss
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
-    bucketOwner: latiss
+    bucketOwner: butler
     bucketMaxSize: 10Ti
     bucketPolicy: |
       {
@@ -59,14 +59,6 @@ spec:
             "Prefix": "",
             "AbortIncompleteMultipartUpload": {
               "DaysAfterInitiation": 1
-            }
-          },
-          {
-            "ID": "ExpireAfter30Days",
-            "Status": "Enabled",
-            "Prefix": "",
-            "Expiration": {
-              "Days": 90
             }
           }
         ]

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubinobs-butler-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubinobs-butler-lsstcam.yaml
@@ -2,13 +2,13 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-butler-lsstcam
+  name: &name rubinobs-butler-lsstcam
   namespace: rook-ceph
 spec:
-  bucketName: rubinobs-butler-lsstcam
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
-    bucketOwner: lsstcam
+    bucketOwner: butler
     bucketMaxSize: 2.5Pi
     bucketPolicy: |
       {
@@ -60,14 +60,6 @@ spec:
             "Prefix": "",
             "AbortIncompleteMultipartUpload": {
               "DaysAfterInitiation": 1
-            }
-          },
-          {
-            "ID": "ExpireAfter30Days",
-            "Status": "Enabled",
-            "Prefix": "",
-            "Expiration": {
-              "Days": 90
             }
           }
         ]

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubinobs-calibrations.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubinobs-calibrations.yaml
@@ -2,10 +2,10 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-calibrations
+  name: &name rubinobs-calibrations
   namespace: rook-ceph
 spec:
-  bucketName: rubinobs-calibrations
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
     bucketOwner: calib

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubinobs-lfa-cp.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubinobs-lfa-cp.yaml
@@ -2,10 +2,10 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-lfa-cp
+  name: &name rubinobs-lfa-cp
   namespace: rook-ceph
 spec:
-  bucketName: rubinobs-lfa-cp
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
     bucketOwner: saluser

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubinobs-raw-comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubinobs-raw-comcam.yaml
@@ -2,12 +2,12 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-raw-comcam
+  name: &name rubinobs-raw-comcam
   namespace: rook-ceph
   labels:
     bucket-notification-lsst.s3.raw.comcam: lsst.s3.raw.comcam
 spec:
-  bucketName: rubinobs-raw-comcam
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
     bucketOwner: comcam

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubinobs-raw-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubinobs-raw-latiss.yaml
@@ -2,12 +2,12 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-raw-latiss
+  name: &name rubinobs-raw-latiss
   namespace: rook-ceph
   labels:
     bucket-notification-lsst.s3.raw.latiss: lsst.s3.raw.latiss
 spec:
-  bucketName: rubinobs-raw-latiss
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
     bucketOwner: latiss

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubinobs-raw-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubinobs-raw-lsstcam.yaml
@@ -2,12 +2,12 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-raw-lsstcam
+  name: &name rubinobs-raw-lsstcam
   namespace: rook-ceph
   labels:
     bucket-notification-lsst.s3.raw.lsstcam: lsst.s3.raw.lsstcam
 spec:
-  bucketName: rubinobs-raw-lsstcam
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
     bucketOwner: lsstcam

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubintv.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/obc-rubintv.yaml
@@ -2,10 +2,10 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubintv
+  name: &name rubintv
   namespace: rook-ceph
 spec:
-  bucketName: rubintv
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
     bucketOwner: rubintv

--- a/fleet/lib/rook-ceph-conf/charts/elqui/values.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/values.yaml
@@ -4,11 +4,12 @@ users:
     spec:
       store: lfa
       quotas:
-        maxBuckets: 2
-        maxSize: 2Pi
+        maxBuckets: 3
   - name: calib
     spec:
       store: lfa
+      quotas:
+        maxBuckets: 1
   - name: comcam
     spec:
       store: lfa
@@ -27,12 +28,18 @@ users:
   - name: oods-comcam
     spec:
       store: lfa
+      quotas:
+        maxBuckets: 0
   - name: oods-latiss
     spec:
       store: lfa
+      quotas:
+        maxBuckets: 0
   - name: oods-lsstcam
     spec:
       store: lfa
+      quotas:
+        maxBuckets: 0
   - name: rubintv
     spec:
       store: lfa

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstoreuser-extended-ceph-exporter.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstoreuser-extended-ceph-exporter.yaml
@@ -10,7 +10,7 @@ spec:
   displayName: extended-ceph-exporter
   capabilities:
     buckets: read
-    users: read
-    usage: read
     metadata: read
+    usage: read
+    users: read
     zone: read

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/obc-rubinobs-butler-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/obc-rubinobs-butler-latiss.yaml
@@ -8,7 +8,7 @@ spec:
   bucketName: *name
   storageClassName: lfa
   additionalConfig:
-    bucketOwner: latiss
+    bucketOwner: butler
     bucketMaxSize: 1Ti
     bucketPolicy: |
       {

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/obc-rubinobs-butler-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/obc-rubinobs-butler-lsstcam.yaml
@@ -8,7 +8,7 @@ spec:
   bucketName: *name
   storageClassName: lfa
   additionalConfig:
-    bucketOwner: lsstcam
+    bucketOwner: butler
     bucketMaxSize: 34Ti
     bucketPolicy: |
       {

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/obc-rubinobs-calibrations.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/obc-rubinobs-calibrations.yaml
@@ -43,6 +43,21 @@ spec:
                       "arn:aws:s3:::rubinobs-calibrations",
                       "arn:aws:s3:::rubinobs-calibrations/*"
                   ]
+              },
+              {
+                  "Effect": "Allow",
+                  "Principal": {
+                      "AWS": "arn:aws:iam:::user/oods-lsstcam"
+                  },
+                  "Action": [
+                      "s3:GetObject",
+                      "s3:ListBucket",
+                      "s3:GetBucketLocation"
+                  ],
+                  "Resource": [
+                      "arn:aws:s3:::rubinobs-calibrations",
+                      "arn:aws:s3:::rubinobs-calibrations/*"
+                  ]
               }
           ]
       }

--- a/fleet/lib/rook-ceph-conf/charts/konkong/values.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/values.yaml
@@ -8,6 +8,8 @@ users:
   - name: calib
     spec:
       store: lfa
+      quotas:
+        maxBuckets: 1
   - name: latiss
     spec:
       store: lfa
@@ -21,9 +23,13 @@ users:
   - name: oods-latiss
     spec:
       store: lfa
+      quotas:
+        maxBuckets: 0
   - name: oods-lsstcam
     spec:
       store: lfa
+      quotas:
+        maxBuckets: 0
   - name: rubintv
     spec:
       store: lfa
@@ -33,4 +39,4 @@ users:
     spec:
       store: lfa
       quotas:
-        maxBuckets: 2
+        maxBuckets: 1

--- a/fleet/lib/rook-ceph-conf/charts/pillan/values.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/values.yaml
@@ -14,15 +14,19 @@ users:
     spec:
       store: lfa
       quotas:
-        maxBuckets: 1
+        maxBuckets: 2
   - name: latiss
     spec:
       store: lfa
       quotas:
-        maxBuckets: 1
+        maxBuckets: 2
   - name: oods-comcam
     spec:
       store: lfa
+      quotas:
+        maxBuckets: 0
   - name: oods-latiss
     spec:
       store: lfa
+      quotas:
+        maxBuckets: 0

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubinobs-butler-comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubinobs-butler-comcam.yaml
@@ -2,13 +2,13 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-butler-comcam
+  name: &name rubinobs-butler-comcam
   namespace: rook-ceph
 spec:
-  bucketName: rubinobs-butler-comcam
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
-    bucketOwner: comcam
+    bucketOwner: butler
     bucketMaxSize: 20Ti
     bucketPolicy: |
       {

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubinobs-butler-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubinobs-butler-latiss.yaml
@@ -2,13 +2,13 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-butler-latiss
+  name: &name rubinobs-butler-latiss
   namespace: rook-ceph
 spec:
-  bucketName: rubinobs-butler-latiss
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
-    bucketOwner: latiss
+    bucketOwner: butler
     bucketMaxSize: 10Ti
     bucketPolicy: |
       {

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubinobs-butler-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubinobs-butler-lsstcam.yaml
@@ -2,13 +2,13 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-butler-lsstcam
+  name: &name rubinobs-butler-lsstcam
   namespace: rook-ceph
 spec:
-  bucketName: rubinobs-butler-lsstcam
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
-    bucketOwner: lsstcam
+    bucketOwner: butler
     bucketMaxSize: 2.5Pi
     bucketPolicy: |
       {

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubinobs-calibrations.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubinobs-calibrations.yaml
@@ -2,10 +2,10 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-calibrations
+  name: &name rubinobs-calibrations
   namespace: rook-ceph
 spec:
-  bucketName: rubinobs-calibrations
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
     bucketOwner: calib

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubinobs-lfa-cp.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubinobs-lfa-cp.yaml
@@ -2,10 +2,10 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-lfa-cp
+  name: &name rubinobs-lfa-cp
   namespace: rook-ceph
 spec:
-  bucketName: rubinobs-lfa-cp
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
     bucketOwner: saluser

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubinobs-raw-comcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubinobs-raw-comcam.yaml
@@ -2,12 +2,12 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-raw-comcam
+  name: &name rubinobs-raw-comcam
   namespace: rook-ceph
   labels:
     bucket-notification-lsst.s3.raw.comcam: lsst.s3.raw.comcam
 spec:
-  bucketName: rubinobs-raw-comcam
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
     bucketOwner: comcam
@@ -62,7 +62,7 @@ spec:
             }
           },
           {
-            "ID": "ExpireAfter30Days",
+            "ID": "ExpireAfter90Days",
             "Status": "Enabled",
             "Prefix": "",
             "Expiration": {

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubinobs-raw-latiss.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubinobs-raw-latiss.yaml
@@ -2,12 +2,12 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-raw-latiss
+  name: &name rubinobs-raw-latiss
   namespace: rook-ceph
   labels:
     bucket-notification-lsst.s3.raw.latiss: lsst.s3.raw.latiss
 spec:
-  bucketName: rubinobs-raw-latiss
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
     bucketOwner: latiss
@@ -62,7 +62,7 @@ spec:
             }
           },
           {
-            "ID": "ExpireAfter30Days",
+            "ID": "ExpireAfter90Days",
             "Status": "Enabled",
             "Prefix": "",
             "Expiration": {

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubinobs-raw-lsstcam.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubinobs-raw-lsstcam.yaml
@@ -2,12 +2,12 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubinobs-raw-lsstcam
+  name: &name rubinobs-raw-lsstcam
   namespace: rook-ceph
   labels:
     bucket-notification-lsst.s3.raw.lsstcam: lsst.s3.raw.lsstcam
 spec:
-  bucketName: rubinobs-raw-lsstcam
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
     bucketOwner: lsstcam
@@ -62,7 +62,7 @@ spec:
             }
           },
           {
-            "ID": "ExpireAfter30Days",
+            "ID": "ExpireAfter90Days",
             "Status": "Enabled",
             "Prefix": "",
             "Expiration": {

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubintv.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/obc-rubintv.yaml
@@ -2,10 +2,10 @@
 apiVersion: objectbucket.io/v1alpha1
 kind: ObjectBucketClaim
 metadata:
-  name: rubintv
+  name: &name rubintv
   namespace: rook-ceph
 spec:
-  bucketName: rubintv
+  bucketName: *name
   storageClassName: lfa
   additionalConfig:
     bucketOwner: rubintv

--- a/fleet/lib/rook-ceph-conf/charts/ruka/values.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/values.yaml
@@ -4,11 +4,12 @@ users:
     spec:
       store: lfa
       quotas:
-        maxBuckets: 2
-        maxSize: 2Pi
+        maxBuckets: 3
   - name: calib
     spec:
       store: lfa
+      quotas:
+        maxBuckets: 1
   - name: comcam
     spec:
       store: lfa
@@ -27,12 +28,18 @@ users:
   - name: oods-comcam
     spec:
       store: lfa
+      quotas:
+        maxBuckets: 0
   - name: oods-latiss
     spec:
       store: lfa
+      quotas:
+        maxBuckets: 0
   - name: oods-lsstcam
     spec:
       store: lfa
+      quotas:
+        maxBuckets: 0
   - name: rubintv
     spec:
       store: lfa


### PR DESCRIPTION
This is a partial re-sync of cross sight configuration.  TTS remains mostly out of sync with the other sites.  As the configuration has continued to grow, this manual re-sync'ing is increasingly tedious.  In the future, we may want to move the oods/etc. related configure into its own chart and live with comcam buckets/etc. being configured in the bts so as to minimize the cross-site differences.