### PR TITLE
(fleet/bundles) change clustername to clusterSelector for LS

### DIFF
--- a/fleet/lib/ccs-grafana/fleet.yaml
+++ b/fleet/lib/ccs-grafana/fleet.yaml
@@ -19,7 +19,12 @@ dependsOn:
         bundle: ccs-influxdb
 targetCustomizations:
   - name: manke
-    clusterName: manke
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - manke
     helm:
       valuesFiles:
         - overlays/manke/values.yaml

--- a/fleet/lib/ccs-influxdb/fleet.yaml
+++ b/fleet/lib/ccs-influxdb/fleet.yaml
@@ -15,7 +15,12 @@ helm:
     - values.yaml
 targetCustomizations:
   - name: manke
-    clusterName: manke
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - manke
     helm:
       valuesFiles:
         - overlays/manke/values.yaml

--- a/fleet/lib/cert-manager-conf/fleet.yaml
+++ b/fleet/lib/cert-manager-conf/fleet.yaml
@@ -20,7 +20,12 @@ dependsOn:
         bundle: external-secrets
 targetCustomizations:
   - name: konkong
-    clusterName: konkong
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - konkong
     kustomize:
       dir: overlays/konkong
   - name: dev

--- a/fleet/lib/cnpg-cluster/fleet.yaml
+++ b/fleet/lib/cnpg-cluster/fleet.yaml
@@ -22,7 +22,12 @@ dependsOn:
         bundle: prometheus-operator-crds
 targetCustomizations:
   - name: manke
-    clusterName: manke
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - manke
     yaml:
       overlays:
         - manke

--- a/fleet/lib/fleet-conf/overlays/ls/gitrepo-antu.yaml
+++ b/fleet/lib/fleet-conf/overlays/ls/gitrepo-antu.yaml
@@ -12,6 +12,11 @@ spec:
     - fleet/s/ls/c/antu/*
   targets:
     - name: antu
-      clusterName: antu
+      clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - antu
   correctDrift:
     enabled: true

--- a/fleet/lib/fleet-conf/overlays/ls/gitrepo-gaw.yaml
+++ b/fleet/lib/fleet-conf/overlays/ls/gitrepo-gaw.yaml
@@ -12,6 +12,11 @@ spec:
     - fleet/s/ls/c/gaw/*
   targets:
     - name: gaw
-      clusterName: gaw
+      clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - gaw
   correctDrift:
     enabled: true

--- a/fleet/lib/fleet-conf/overlays/ls/gitrepo-konkong.yaml
+++ b/fleet/lib/fleet-conf/overlays/ls/gitrepo-konkong.yaml
@@ -12,6 +12,11 @@ spec:
     - fleet/s/ls/c/konkong/*
   targets:
     - name: konkong
-      clusterName: konkong
+      clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - konkong
   correctDrift:
     enabled: true

--- a/fleet/lib/fleet-conf/overlays/ls/gitrepo-luan.yaml
+++ b/fleet/lib/fleet-conf/overlays/ls/gitrepo-luan.yaml
@@ -12,6 +12,11 @@ spec:
     - fleet/s/ls/c/luan/*
   targets:
     - name: luan
-      clusterName: luan
+      clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - luan
   correctDrift:
     enabled: true

--- a/fleet/lib/fleet-conf/overlays/ls/gitrepo-manke.yaml
+++ b/fleet/lib/fleet-conf/overlays/ls/gitrepo-manke.yaml
@@ -12,6 +12,11 @@ spec:
     - fleet/s/ls/c/manke/*
   targets:
     - name: manke
-      clusterName: manke
+      clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - manke
   correctDrift:
     enabled: true

--- a/fleet/lib/htcondor/fleet.yaml
+++ b/fleet/lib/htcondor/fleet.yaml
@@ -11,7 +11,12 @@ dependsOn:
         bundle: external-secrets
 targetCustomizations:
   - name: manke
-    clusterName: manke
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - manke
     yaml:
       overlays:
         - manke

--- a/fleet/lib/keycloak-pg/fleet.yaml
+++ b/fleet/lib/keycloak-pg/fleet.yaml
@@ -14,7 +14,12 @@ dependsOn:
         bundle: cnpg-system
 targetCustomizations:
   - name: luan
-    clusterName: luan
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - luan
     yaml:
       overlays:
         - generic

--- a/fleet/lib/keycloak/fleet.yaml
+++ b/fleet/lib/keycloak/fleet.yaml
@@ -22,7 +22,12 @@ dependsOn:
         bundle: keycloak-pg
 targetCustomizations:
   - name: luan
-    clusterName: luan
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - luan
     helm:
       valuesFiles:
         - overlays/luan/values.yaml

--- a/fleet/lib/kube-prometheus-stack/fleet.yaml
+++ b/fleet/lib/kube-prometheus-stack/fleet.yaml
@@ -83,7 +83,12 @@ targetCustomizations:
         - ldap/values.yaml
         - overlays/ruka/values.yaml
   - name: antu
-    clusterName: antu
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - antu
     helm:
       valuesFiles:
         - pvc/values.yaml

--- a/fleet/lib/metallb-conf/fleet.yaml
+++ b/fleet/lib/metallb-conf/fleet.yaml
@@ -54,22 +54,42 @@ targetCustomizations:
       overlays:
         - pillan
   - name: gaw
-    clusterName: gaw
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - gaw
     yaml:
       overlays:
         - gaw
   - name: luan
-    clusterName: luan
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - luan
     yaml:
       overlays:
         - luan
   - name: konkong
-    clusterName: konkong
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - konkong
     yaml:
       overlays:
         - konkong
   - name: manke
-    clusterName: manke
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - manke
     yaml:
       overlays:
         - manke
@@ -89,7 +109,12 @@ targetCustomizations:
       overlays:
         - yepun
   - name: antu
-    clusterName: antu
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - antu
     yaml:
       overlays:
         - antu

--- a/fleet/lib/metallb-demo/fleet.yaml
+++ b/fleet/lib/metallb-demo/fleet.yaml
@@ -31,14 +31,24 @@ targetCustomizations:
         pools:
           - general
   - name: konkong
-    clusterName: konkong
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - konkong
     helm:
       values:
         pools:
           - default
           - lhn
   - name: manke
-    clusterName: manke
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - manke
     helm:
       values:
         pools:

--- a/fleet/lib/mimir-pre/fleet.yaml
+++ b/fleet/lib/mimir-pre/fleet.yaml
@@ -45,7 +45,12 @@ targetCustomizations:
       overlays:
         - ayekan
   - name: antu
-    clusterName: antu
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - antu
     yaml:
       overlays:
         - antu

--- a/fleet/lib/multus-conf/fleet.yaml
+++ b/fleet/lib/multus-conf/fleet.yaml
@@ -44,12 +44,22 @@ targetCustomizations:
       overlays:
         - pillan
   - name: konkong
-    clusterName: konkong
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - konkong
     yaml:
       overlays:
         - konkong
   - name: manke
-    clusterName: manke
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - manke
     yaml:
       overlays:
         - manke

--- a/fleet/lib/multus-demo/fleet.yaml
+++ b/fleet/lib/multus-demo/fleet.yaml
@@ -43,13 +43,23 @@ targetCustomizations:
         networks:
           - dds
   - name: konkong
-    clusterName: konkong
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - konkong
     helm:
       values:
         networks:
           - lhn
   - name: manke
-    clusterName: manke
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - manke
     helm:
       values:
         networks:

--- a/fleet/lib/rook-ceph-cluster/fleet.yaml
+++ b/fleet/lib/rook-ceph-cluster/fleet.yaml
@@ -85,22 +85,42 @@ targetCustomizations:
       valuesFiles:
         - overlays/pillan/values.yaml
   - name: gaw
-    clusterName: gaw
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - gaw
     helm:
       valuesFiles:
         - overlays/gaw/values.yaml
   - name: luan
-    clusterName: luan
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - luan
     helm:
       valuesFiles:
         - overlays/luan/values.yaml
   - name: konkong
-    clusterName: konkong
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - konkong
     helm:
       valuesFiles:
         - overlays/konkong/values.yaml
   - name: manke
-    clusterName: manke
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - manke
     helm:
       valuesFiles:
         - overlays/manke/values.yaml
@@ -120,7 +140,12 @@ targetCustomizations:
       valuesFiles:
         - overlays/yepun/values.yaml
   - name: antu
-    clusterName: antu
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - antu
     helm:
       valuesFiles:
         - overlays/antu/values.yaml

--- a/fleet/lib/rook-ceph-conf/fleet.yaml
+++ b/fleet/lib/rook-ceph-conf/fleet.yaml
@@ -75,28 +75,48 @@ targetCustomizations:
           pillan:
             enabled: true
   - name: gaw
-    clusterName: gaw
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - gaw
     helm:
       values:
         subchart:
           gaw:
             enabled: true
   - name: luan
-    clusterName: luan
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - luan
     helm:
       values:
         subchart:
           luan:
             enabled: true
   - name: konkong
-    clusterName: konkong
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - konkong
     helm:
       values:
         subchart:
           konkong:
             enabled: true
   - name: manke
-    clusterName: manke
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - manke
     helm:
       values:
         subchart:
@@ -124,7 +144,12 @@ targetCustomizations:
           yepun:
             enabled: true
   - name: antu
-    clusterName: antu
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - antu
     helm:
       values:
         subchart:

--- a/fleet/lib/rook-ceph-demo/fleet.yaml
+++ b/fleet/lib/rook-ceph-demo/fleet.yaml
@@ -85,7 +85,12 @@ targetCustomizations:
               path: /scratch
               server: nfs-scratch.tu.lsst.org
   - name: gaw
-    clusterName: gaw
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - gaw
     helm:
       values:
         pvc:
@@ -97,7 +102,12 @@ targetCustomizations:
               path: /backup
               server: 139.229.135.203
   - name: manke
-    clusterName: manke
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - manke
     helm:
       values:
         pvc:
@@ -126,18 +136,6 @@ targetCustomizations:
             - name: scratch
               path: /scratch
               server: nfs-scratch.ls.lsst.org
-  - name: gaw
-    clusterName: gaw
-    helm:
-      values:
-        pvc:
-          enabled: true
-        nfs:
-          enabled: true
-          mounts:
-            - name: backup
-              path: /backup
-              server: it-nfs-backup.cp.lsst.org
   - name: yagan
     clusterName: yagan
     helm:
@@ -237,7 +235,12 @@ targetCustomizations:
               path: /scratch
               server: nfs-scratch.cp.lsst.org
   - name: konkong
-    clusterName: konkong
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - konkong
     helm:
       values:
         nfs:


### PR DESCRIPTION
this PR changes the `clusterName` for fleet that got randomized on the last version into `clusterSelector` to match the name of the cluster, this affects all base clusters.
this PR hangs from https://github.com/lsst-it/k8s-cookbook/pull/943/