### PR TITLE
(cp/yagan) Increase CPU from 16 to 48

### DIFF
--- a/fleet/lib/cnpg-cluster/overlays/yagan/cluster-cnpg-cluster.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/yagan/cluster-cnpg-cluster.yaml
@@ -34,15 +34,15 @@ spec:
     name: cnpg-cluster-superuser
 
   storage:
-    size: 150Gi
+    size: 200Gi
 
   monitoring:
     enablePodMonitor: true
 
   resources:
     limits:
-      cpu: "16"
+      cpu: "48"
       memory: 64Gi
     requests:
-      cpu: "16"
+      cpu: "48"
       memory: 64Gi


### PR DESCRIPTION
These changes were necessary due to persistent 100% CPU utilization on the primary node (cnpg-cluster-8).

Changes applied:
- Increase CPU from 16 to 48

Closes: https://rubinobs.atlassian.net/browse/IT-6219