### PR TITLE
(fleet/cnpg-cluster) bump cnpgsphere 16.8 on pillan

### DIFF
--- a/fleet/lib/cnpg-cluster/overlays/pillan/cluster-cnpg-cluster.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/pillan/cluster-cnpg-cluster.yaml
@@ -5,7 +5,7 @@ kind: Cluster
 metadata:
   name: cnpg-cluster
 spec:
-  imageName: docker.io/lsstit/cnpgsphere:14.5
+  imageName: docker.io/lsstit/cnpgsphere:16.8
   imagePullPolicy: IfNotPresent
 
   instances: 2


### PR DESCRIPTION
bumping `postgres` version on the `TTS` to `16.8`