### PR TITLE
(fleet/rook-ceph-conf) set 3PiB on lfa data pool on elqui.

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstore-lfa.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstore-lfa.yaml
@@ -347,6 +347,8 @@ spec:
     pg_autoscale_mode: "off"
     bulk: "true"
     pg_num: "2048"
+  quotas:
+    maxSize: 3Pi
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass


### PR DESCRIPTION
- the user for the `LFA` has a BucketMaxSize of 2.5PiB so, just in case, we are setting the quota on the data pool to 3PiB.