### PR TITLE
(bundles/fleet) fix CP clusterName to clusterSelector

### DIFF
--- a/fleet/lib/ccs-grafana/fleet.yaml
+++ b/fleet/lib/ccs-grafana/fleet.yaml
@@ -39,7 +39,12 @@ targetCustomizations:
       valuesFiles:
         - overlays/pillan/values.yaml
   - name: yagan
-    clusterName: yagan
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - yagan
     helm:
       valuesFiles:
         - overlays/yagan/values.yaml

--- a/fleet/lib/ccs-influxdb/fleet.yaml
+++ b/fleet/lib/ccs-influxdb/fleet.yaml
@@ -35,7 +35,12 @@ targetCustomizations:
       valuesFiles:
         - overlays/pillan/values.yaml
   - name: yagan
-    clusterName: yagan
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - yagan
     helm:
       valuesFiles:
         - overlays/yagan/values.yaml

--- a/fleet/lib/cnpg-cluster/fleet.yaml
+++ b/fleet/lib/cnpg-cluster/fleet.yaml
@@ -52,7 +52,12 @@ targetCustomizations:
       overlays:
         - ruka
   - name: yagan
-    clusterName: yagan
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - yagan
     yaml:
       overlays:
         - yagan

--- a/fleet/lib/fleet-conf/overlays/cp/gitrepo-elqui.yaml
+++ b/fleet/lib/fleet-conf/overlays/cp/gitrepo-elqui.yaml
@@ -12,6 +12,11 @@ spec:
     - fleet/s/cp/c/elqui/*
   targets:
     - name: elqui
-      clusterName: elqui
+      clusterSelector:
+        matchExpressions:
+          - key: management.cattle.io/cluster-display-name
+            operator: In
+            values:
+              - elqui
   correctDrift:
     enabled: true

--- a/fleet/lib/fleet-conf/overlays/cp/gitrepo-lukay.yaml
+++ b/fleet/lib/fleet-conf/overlays/cp/gitrepo-lukay.yaml
@@ -12,6 +12,11 @@ spec:
     - fleet/s/cp/c/lukay/*
   targets:
     - name: lukay
-      clusterName: lukay
+      clusterSelector:
+        matchExpressions:
+          - key: management.cattle.io/cluster-display-name
+            operator: In
+            values:
+              - lukay
   correctDrift:
     enabled: true

--- a/fleet/lib/fleet-conf/overlays/cp/gitrepo-yagan.yaml
+++ b/fleet/lib/fleet-conf/overlays/cp/gitrepo-yagan.yaml
@@ -12,6 +12,11 @@ spec:
     - fleet/s/cp/c/yagan/*
   targets:
     - name: yagan
-      clusterName: yagan
+      clusterSelector:
+        matchExpressions:
+          - key: management.cattle.io/cluster-display-name
+            operator: In
+            values:
+              - yagan
   correctDrift:
     enabled: true

--- a/fleet/lib/fleet-conf/overlays/cp/gitrepo-yepun.yaml
+++ b/fleet/lib/fleet-conf/overlays/cp/gitrepo-yepun.yaml
@@ -12,6 +12,11 @@ spec:
     - fleet/s/cp/c/yepun/*
   targets:
     - name: yepun
-      clusterName: yepun
+      clusterSelector:
+        matchExpressions:
+          - key: management.cattle.io/cluster-display-name
+            operator: In
+            values:
+              - yepun
   correctDrift:
     enabled: true

--- a/fleet/lib/htcondor/fleet.yaml
+++ b/fleet/lib/htcondor/fleet.yaml
@@ -31,7 +31,12 @@ targetCustomizations:
       overlays:
         - ruka
   - name: yagan
-    clusterName: yagan
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - yagan
     yaml:
       overlays:
         - yagan

--- a/fleet/lib/keycloak-pg/fleet.yaml
+++ b/fleet/lib/keycloak-pg/fleet.yaml
@@ -36,7 +36,12 @@ targetCustomizations:
         - generic
         - ruka
   - name: yepun
-    clusterName: yepun
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - yepun
     yaml:
       overlays:
         - generic

--- a/fleet/lib/keycloak/fleet.yaml
+++ b/fleet/lib/keycloak/fleet.yaml
@@ -42,7 +42,12 @@ targetCustomizations:
       valuesFiles:
         - overlays/pillan/values.yaml
   - name: yepun
-    clusterName: yepun
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - yepun
     helm:
       valuesFiles:
         - overlays/yepun/values.yaml

--- a/fleet/lib/metallb-conf/fleet.yaml
+++ b/fleet/lib/metallb-conf/fleet.yaml
@@ -94,17 +94,32 @@ targetCustomizations:
       overlays:
         - manke
   - name: lukay
-    clusterName: lukay
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - lukay
     yaml:
       overlays:
         - lukay
   - name: yagan
-    clusterName: yagan
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - yagan
     yaml:
       overlays:
         - yagan
   - name: yepun
-    clusterName: yepun
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - yepun
     yaml:
       overlays:
         - yepun
@@ -119,7 +134,12 @@ targetCustomizations:
       overlays:
         - antu
   - name: elqui
-    clusterName: elqui
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - elqui
     yaml:
       overlays:
         - elqui

--- a/fleet/lib/metallb-demo/fleet.yaml
+++ b/fleet/lib/metallb-demo/fleet.yaml
@@ -55,13 +55,23 @@ targetCustomizations:
           - general
           - lhn
   - name: yagan
-    clusterName: yagan
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - yagan
     helm:
       values:
         pools:
           - general
   - name: elqui
-    clusterName: elqui
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - elqui
     helm:
       values:
         pools:

--- a/fleet/lib/multus-conf/fleet.yaml
+++ b/fleet/lib/multus-conf/fleet.yaml
@@ -64,7 +64,12 @@ targetCustomizations:
       overlays:
         - manke
   - name: yagan
-    clusterName: yagan
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - yagan
     yaml:
       overlays:
         - yagan

--- a/fleet/lib/multus-demo/fleet.yaml
+++ b/fleet/lib/multus-demo/fleet.yaml
@@ -66,7 +66,12 @@ targetCustomizations:
           - dds
           - lhn
   - name: yagan
-    clusterName: yagan
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - yagan
     helm:
       values:
         networks:

--- a/fleet/lib/nexus/fleet.yaml
+++ b/fleet/lib/nexus/fleet.yaml
@@ -62,7 +62,12 @@ dependsOn:
         bundle: cert-manager-crds
 targetCustomizations:
   - name: yepun
-    clusterName: yepun
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - yepun
     helm:
       values:
         persistence:

--- a/fleet/lib/rook-ceph-cluster/fleet.yaml
+++ b/fleet/lib/rook-ceph-cluster/fleet.yaml
@@ -125,17 +125,32 @@ targetCustomizations:
       valuesFiles:
         - overlays/manke/values.yaml
   - name: lukay
-    clusterName: lukay
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - lukay
     helm:
       valuesFiles:
         - overlays/lukay/values.yaml
   - name: yagan
-    clusterName: yagan
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - yagan
     helm:
       valuesFiles:
         - overlays/yagan/values.yaml
   - name: yepun
-    clusterName: yepun
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - yepun
     helm:
       valuesFiles:
         - overlays/yepun/values.yaml
@@ -150,7 +165,12 @@ targetCustomizations:
       valuesFiles:
         - overlays/antu/values.yaml
   - name: elqui
-    clusterName: elqui
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - elqui
     helm:
       valuesFiles:
         - overlays/elqui/values.yaml

--- a/fleet/lib/rook-ceph-conf/fleet.yaml
+++ b/fleet/lib/rook-ceph-conf/fleet.yaml
@@ -123,21 +123,36 @@ targetCustomizations:
           manke:
             enabled: true
   - name: lukay
-    clusterName: lukay
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - lukay
     helm:
       values:
         subchart:
           lukay:
             enabled: true
   - name: yagan
-    clusterName: yagan
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - yagan
     helm:
       values:
         subchart:
           yagan:
             enabled: true
   - name: yepun
-    clusterName: yepun
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - yepun
     helm:
       values:
         subchart:
@@ -156,7 +171,12 @@ targetCustomizations:
           antu:
             enabled: true
   - name: elqui
-    clusterName: elqui
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - elqui
     helm:
       values:
         subchart:

--- a/fleet/lib/rook-ceph-demo/fleet.yaml
+++ b/fleet/lib/rook-ceph-demo/fleet.yaml
@@ -137,7 +137,12 @@ targetCustomizations:
               path: /scratch
               server: nfs-scratch.ls.lsst.org
   - name: yagan
-    clusterName: yagan
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - yagan
     helm:
       values:
         pvc:
@@ -187,7 +192,12 @@ targetCustomizations:
         pvc:
           enabled: true
   - name: lukay
-    clusterName: lukay
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - lukay
     helm:
       values:
         pvc:
@@ -199,7 +209,12 @@ targetCustomizations:
               path: /backup
               server: 139.229.160.212
   - name: elqui
-    clusterName: elqui
+    clusterSelector:
+      matchExpressions:
+        - key: management.cattle.io/cluster-display-name
+          operator: In
+          values:
+            - elqui
     helm:
       values:
         pvc:


### PR DESCRIPTION
- changes the old `clusterName` to `clusterSelector` because of rancher's new behavior for the summit clusters.