### PR TITLE
(kueyen) Remove service allowing use of default Ingress with Loki

### DIFF
--- a/fleet/lib/loki/overlays/kueyen/values.yaml
+++ b/fleet/lib/loki/overlays/kueyen/values.yaml
@@ -35,9 +35,6 @@ indexGateway:
   replicas: 1
 
 gateway:
-  service:
-    type: LoadBalancer
-    port: 80
   ingress:
     hosts:
       - host: loki.kueyen.dev.lsst.org
@@ -45,6 +42,6 @@ gateway:
           - path: /
             pathType: Prefix
     tls:
-      - secretName: loki-dashboard-ingress-tls
+      - secretName: tls-loki-ingress
         hosts:
           - loki.kueyen.dev.lsst.org

--- a/fleet/lib/loki/values.yaml
+++ b/fleet/lib/loki/values.yaml
@@ -43,9 +43,6 @@ deploymentMode: Distributed
 
 gateway:
   enabled: true
-  service:
-    type: LoadBalancer
-    port: 80
   ingress:
     enabled: true
     ingressClassName: nginx


### PR DESCRIPTION
- Remove Service as `LoadBalancer`, leaving `ClusterIP` as the default Service Type from the values.
- Update secret name as `tls-loki-ingress`.

Unblocks PR: #963 