### PR TITLE
(ruka) reduce rgw pool pg sizes

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstore-lfa.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstore-lfa.yaml
@@ -190,7 +190,7 @@ spec:
     nodelete: "true"
     nosizechange: "true"
     pg_autoscale_mode: "off"
-    pg_num: "256"
+    pg_num: "32"
   replicated:
     size: 3
 ---
@@ -242,7 +242,7 @@ spec:
     nosizechange: "true"
     pg_autoscale_mode: "off"
     bulk: "true"
-    pg_num: "512"
+    pg_num: "64"
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass


### PR DESCRIPTION
To resolve this warning:

    health: HEALTH_WARN
            Reduced data availability: 32 pgs inactive, 32 pgs incomplete
            too many PGs per OSD (408 > max 250)