### PR TITLE
(pillan) add rgw calib, rubintv, & saluser users

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/pillan/values.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/values.yaml
@@ -5,6 +5,11 @@ users:
       store: lfa
       quotas:
         maxBuckets: 2
+  - name: calib
+    spec:
+      store: lfa
+      quotas:
+        maxBuckets: 1
   - name: ccs
     spec:
       store: lfa
@@ -30,3 +35,13 @@ users:
       store: lfa
       quotas:
         maxBuckets: 0
+  - name: rubintv
+    spec:
+      store: lfa
+      quotas:
+        maxBuckets: 1
+  - name: saluser
+    spec:
+      store: lfa
+      quotas:
+        maxBuckets: 1


### PR DESCRIPTION
Credentials have been copied from pillan rgw (or created from scratch) in the 1pass `oods.tu` vault for these users.