### PR TITLE
(fleet/loki) Fix maxUnavailable on Antu

### DIFF
--- a/fleet/lib/loki/overlays/antu/values.yaml
+++ b/fleet/lib/loki/overlays/antu/values.yaml
@@ -13,9 +13,11 @@ ingester:
 
 distributor:
   replicas: 2
+  maxUnavailable: 1
 
 querier:
   replicas: 2
+  maxUnavailable: 1
 
 queryFrontend:
   replicas: 2
@@ -23,6 +25,8 @@ queryFrontend:
 
 queryScheduler:
   replicas: 2
+  maxUnavailable: 1
 
 indexGateway:
   replicas: 2
+  maxUnavailable: 1


### PR DESCRIPTION
This pull request introduces a minor configuration update to the `fleet/lib/loki/overlays/antu/values.yaml` file. The change adds a `maxUnavailable` setting to the `queryFrontend` configuration, specifying the maximum number of pods that can be unavailable during an update.

* Configuration update:
  * [`fleet/lib/loki/overlays/antu/values.yaml`](diffhunk://#diff-ad9326c72cdec0a813b4139701aa667b387b85354e8a4cb084458faa9eba9ceeR22): Added `maxUnavailable: 1` to the `queryFrontend` configuration to improve update management.