### PR TITLE
(fleet/cnpg-cluster) bump backup image to pg16.8

### DIFF
--- a/fleet/lib/cnpg-cluster/overlays/manke/cnpg-backup.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/manke/cnpg-backup.yaml
@@ -40,7 +40,7 @@ spec:
           activeDeadlineSeconds: 3600
           containers:
             - name: cnpg-backup
-              image: docker.io/lsstit/cnpg-backup:0.5
+              image: docker.io/lsstit/cnpg-backup:0.6
               volumeMounts:
                 - name: ephemeral
                   mountPath: /tmp

--- a/fleet/lib/cnpg-cluster/overlays/pillan/cnpg-backup.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/pillan/cnpg-backup.yaml
@@ -40,7 +40,7 @@ spec:
           activeDeadlineSeconds: 3600
           containers:
             - name: cnpg-backup
-              image: docker.io/lsstit/cnpg-backup:0.5
+              image: docker.io/lsstit/cnpg-backup:0.6
               volumeMounts:
                 - name: ephemeral
                   mountPath: /tmp

--- a/fleet/lib/cnpg-cluster/overlays/ruka/cnpg-backup.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/ruka/cnpg-backup.yaml
@@ -40,7 +40,7 @@ spec:
           activeDeadlineSeconds: 3600
           containers:
             - name: cnpg-backup
-              image: docker.io/lsstit/cnpg-backup:0.5
+              image: docker.io/lsstit/cnpg-backup:0.6
               volumeMounts:
                 - name: ephemeral
                   mountPath: /tmp

--- a/fleet/lib/cnpg-cluster/overlays/yagan/cnpg-backup.yaml
+++ b/fleet/lib/cnpg-cluster/overlays/yagan/cnpg-backup.yaml
@@ -40,7 +40,7 @@ spec:
           activeDeadlineSeconds: 3600
           containers:
             - name: cnpg-backup
-              image: docker.io/lsstit/cnpg-backup:0.5
+              image: docker.io/lsstit/cnpg-backup:0.6
               volumeMounts:
                 - name: ephemeral
                   mountPath: /tmp


### PR DESCRIPTION
bumps the `postgres` image on the backup `cronjob` to `postgres` `16.8`