### PR TITLE
(fleet/nexus) bump nexus storage to 5Ti

### DIFF
--- a/fleet/lib/nexus/fleet.yaml
+++ b/fleet/lib/nexus/fleet.yaml
@@ -32,4 +32,4 @@ targetCustomizations:
     helm:
       values:
         persistence:
-          size: 2Ti
+          size: 5Ti


### PR DESCRIPTION
Bumps storage to 5Ti on nexus CP for now and we will scale up as it starts to fill up. 

For more information on this request please check: https://rubinobs.atlassian.net/browse/IHS-9385 

