### PR TITLE
(fleet/cnpg-system) bump chart to 0.24.0

### DIFF
--- a/fleet/lib/cnpg-system/fleet.yaml
+++ b/fleet/lib/cnpg-system/fleet.yaml
@@ -6,7 +6,7 @@ helm:
   chart: cloudnative-pg
   releaseName: cnpg
   repo: https://cloudnative-pg.github.io/charts
-  version: 0.23.2
+  version: 0.24.0
   takeOwnership: true
   timeoutSeconds: 60
   waitForJobs: true


### PR DESCRIPTION
- this bump chart version to `0.24.0` to reach eventually `0.26.0`

`NAME               	CHART VERSION	APP VERSION	DESCRIPTION                      
cnpg/cloudnative-pg	0.26.0       	1.27.0     	CloudNativePG Operator Helm Chart
cnpg/cloudnative-pg	0.25.0       	1.26.1     	CloudNativePG Operator Helm Chart
cnpg/cloudnative-pg	0.24.0       	1.26.0     	CloudNativePG Operator Helm Chart
cnpg/cloudnative-pg	0.23.2       	1.25.1     	CloudNativePG Operator Helm Chart`