### PR TITLE
(fleet/cnpg-system) bump chart to 0.25.0

### DIFF
--- a/fleet/lib/cnpg-system/fleet.yaml
+++ b/fleet/lib/cnpg-system/fleet.yaml
@@ -6,7 +6,7 @@ helm:
   chart: cloudnative-pg
   releaseName: cnpg
   repo: https://cloudnative-pg.github.io/charts
-  version: 0.24.0
+  version: 0.25.0
   takeOwnership: true
   timeoutSeconds: 60
   waitForJobs: true


### PR DESCRIPTION
- bump to 0.25.0 (almost there 0.26.0) 
- this restarts each instance.