### PR TITLE
(fleet/mimir) increase store_gateway pvc to 100Gi

### DIFF
--- a/fleet/lib/mimir/values.yaml
+++ b/fleet/lib/mimir/values.yaml
@@ -125,7 +125,7 @@ ruler:
       memory: 3Gi
 store_gateway:
   persistentVolume:
-    size: 10Gi
+    size: 100Gi
   replicas: 3
   resources:
     limits:


### PR DESCRIPTION
Per https://grafana.com/docs/mimir/latest/manage/run-production-environment/planning-capacity/, disk should be ~72GiB to support our current active series size of ~5.5M.  Bumping up to 100Gi is to allow some room for growth.