### PR TITLE
(fleet/nexus) add nexus pg env variables dev

### DIFF
--- a/fleet/lib/nexus-pre/external-secret-nexus-pg-creds.yaml
+++ b/fleet/lib/nexus-pre/external-secret-nexus-pg-creds.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nexus-pg-creds
+  namespace: nexus
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: nexus-pg-creds
+  data:
+    - secretKey: username
+      remoteRef:
+        key: nexus-postgres-creds
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: nexus-postgres-creds
+        property: password
+    - secretKey: url
+      remoteRef:
+        key: nexus-postgres-creds
+        property: url

--- a/fleet/lib/nexus/values.yaml
+++ b/fleet/lib/nexus/values.yaml
@@ -48,3 +48,20 @@ license:
   enabled: true
   secret: nexus-license
   key: sonatype-license-2025-03-03T185609Z.lic
+
+env:
+  - name: NEXUS_DATASTORE_NEXUS_JDBCURL
+    valueFrom:
+      secretKeyRef:
+        name: nexus-pg-creds
+        key: url
+  - name: NEXUS_DATASTORE_NEXUS_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: nexus-pg-creds
+        key: username
+  - name: NEXUS_DATASTORE_NEXUS_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: nexus-pg-creds
+        key: password


### PR DESCRIPTION
Adds necessary PG env variables on the Nexus instance running on Ruka. This is currently being tested on fleet Ruka and is working as expected. 