### PR TITLE
(ruka) rm fluent-bit-kube bundle

### DIFF
--- a/fleet/s/dev/c/ruka/fluent-bit-kube
+++ b/fleet/s/dev/c/ruka/fluent-bit-kube
@@ -1,1 +1,0 @@
-../../../../lib/fluent-bit-kube


### PR DESCRIPTION
This deployment is unused / broken and is showing an error in fleet.