### PR TITLE
(fleet/rook-ceph-conf) always set a default realm when using CephObjectRealm

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstore-lfa.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ayekan/templates/cephobjectstore-lfa.yaml
@@ -4,6 +4,8 @@ kind: CephObjectRealm
 metadata:
   name: lfa
   namespace: rook-ceph
+spec:
+  defaultRealm: true
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephObjectZoneGroup

--- a/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstore-lfa.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/elqui/templates/cephobjectstore-lfa.yaml
@@ -4,6 +4,8 @@ kind: CephObjectRealm
 metadata:
   name: lfa
   namespace: rook-ceph
+spec:
+  defaultRealm: true
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephObjectZoneGroup

--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-lfa.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-lfa.yaml
@@ -4,6 +4,8 @@ kind: CephObjectRealm
 metadata:
   name: lfa
   namespace: rook-ceph
+spec:
+  defaultRealm: true
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephObjectZoneGroup

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstore-lfa.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstore-lfa.yaml
@@ -4,6 +4,8 @@ kind: CephObjectRealm
 metadata:
   name: lfa
   namespace: rook-ceph
+spec:
+  defaultRealm: true
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephObjectZoneGroup

--- a/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstore-lfa.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/ruka/templates/cephobjectstore-lfa.yaml
@@ -4,6 +4,8 @@ kind: CephObjectRealm
 metadata:
   name: lfa
   namespace: rook-ceph
+spec:
+  defaultRealm: true
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephObjectZoneGroup


### PR DESCRIPTION
This will prevent the automatic creation of `default.rgw...` pools. E.g.
```
default.rgw.log         14   32    182 B        2   24 KiB      0    1.1 TiB
default.rgw.control     15   32      0 B        8      0 B      0    1.1 TiB
default.rgw.meta        16   32      0 B        0      0 B      0    1.1 TiB
```