### PR TITLE
(fleet/rook-ceph-conf) always use cephobjectrealm for rgw conf

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/antu/templates/cephobjectstore-o11y.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/antu/templates/cephobjectstore-o11y.yaml
@@ -1,5 +1,29 @@
 ---
 apiVersion: ceph.rook.io/v1
+kind: CephObjectRealm
+metadata:
+  name: o11y
+  namespace: rook-ceph
+spec:
+  defaultRealm: true
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectZoneGroup
+metadata:
+  name: o11y
+  namespace: rook-ceph
+spec:
+  realm: o11y
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectZone
+metadata:
+  name: o11y
+  namespace: rook-ceph
+spec:
+  zoneGroup: o11y
+---
+apiVersion: ceph.rook.io/v1
 kind: CephObjectStore
 metadata:
   name: o11y
@@ -34,6 +58,8 @@ spec:
       requests:
         cpu: "4"
         memory: 4Gi
+  zone:
+    name: o11y
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/fleet/lib/rook-ceph-conf/charts/gaw/templates/cephobjectstore-k8up-backups.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/gaw/templates/cephobjectstore-k8up-backups.yaml
@@ -1,5 +1,29 @@
 ---
 apiVersion: ceph.rook.io/v1
+kind: CephObjectRealm
+metadata:
+  name: k8up-backups
+  namespace: rook-ceph
+spec:
+  defaultRealm: true
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectZoneGroup
+metadata:
+  name: k8up-backups
+  namespace: rook-ceph
+spec:
+  realm: k8up-backups
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectZone
+metadata:
+  name: k8up-backups
+  namespace: rook-ceph
+spec:
+  zoneGroup: k8up-backups
+---
+apiVersion: ceph.rook.io/v1
 kind: CephObjectStore
 metadata:
   name: k8up-backups
@@ -24,6 +48,8 @@ spec:
     port: 80
     # securePort: 443
     instances: 3
+  zone:
+    name: k8up-backups
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/fleet/lib/rook-ceph-conf/charts/kona/templates/cephobjectstore-o11y.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/kona/templates/cephobjectstore-o11y.yaml
@@ -1,5 +1,29 @@
 ---
 apiVersion: ceph.rook.io/v1
+kind: CephObjectRealm
+metadata:
+  name: o11y
+  namespace: rook-ceph
+spec:
+  defaultRealm: true
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectZoneGroup
+metadata:
+  name: o11y
+  namespace: rook-ceph
+spec:
+  realm: o11y
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectZone
+metadata:
+  name: o11y
+  namespace: rook-ceph
+spec:
+  zoneGroup: o11y
+---
+apiVersion: ceph.rook.io/v1
 kind: CephObjectStore
 metadata:
   name: o11y
@@ -34,6 +58,8 @@ spec:
       requests:
         cpu: "4"
         memory: 4Gi
+  zone:
+    name: o11y
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/fleet/lib/rook-ceph-conf/charts/kueyen/templates/cephobjectstore-o11y.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/kueyen/templates/cephobjectstore-o11y.yaml
@@ -1,5 +1,29 @@
 ---
 apiVersion: ceph.rook.io/v1
+kind: CephObjectRealm
+metadata:
+  name: o11y
+  namespace: rook-ceph
+spec:
+  defaultRealm: true
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectZoneGroup
+metadata:
+  name: o11y
+  namespace: rook-ceph
+spec:
+  realm: o11y
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectZone
+metadata:
+  name: o11y
+  namespace: rook-ceph
+spec:
+  zoneGroup: o11y
+---
+apiVersion: ceph.rook.io/v1
 kind: CephObjectStore
 metadata:
   name: o11y
@@ -34,6 +58,8 @@ spec:
       requests:
         cpu: "4"
         memory: 4Gi
+  zone:
+    name: o11y
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/fleet/lib/rook-ceph-conf/charts/lukay/templates/cephobjectstore-it.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/lukay/templates/cephobjectstore-it.yaml
@@ -1,5 +1,29 @@
 ---
 apiVersion: ceph.rook.io/v1
+kind: CephObjectRealm
+metadata:
+  name: it
+  namespace: rook-ceph
+spec:
+  defaultRealm: true
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectZoneGroup
+metadata:
+  name: it
+  namespace: rook-ceph
+spec:
+  realm: it
+---
+apiVersion: ceph.rook.io/v1
+kind: CephObjectZone
+metadata:
+  name: it
+  namespace: rook-ceph
+spec:
+  zoneGroup: it
+---
+apiVersion: ceph.rook.io/v1
 kind: CephObjectStore
 metadata:
   name: it
@@ -24,6 +48,8 @@ spec:
     port: 80
     # securePort: 443
     instances: 3
+  zone:
+    name: it
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstore-lfa.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/pillan/templates/cephobjectstore-lfa.yaml
@@ -42,6 +42,8 @@ spec:
       requests:
         cpu: "4"
         memory: 4Gi
+  zone:
+    name: lfa
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
This is to ensure there is always a default rgw realm set on clusters running rgw.