### PR TITLE
(fleet/loki) remove s3 keys

### DIFF
--- a/fleet/lib/loki/values.yaml
+++ b/fleet/lib/loki/values.yaml
@@ -45,8 +45,6 @@ loki:
     type: s3
     s3:
       endpoint: http://rook-ceph-rgw-o11y.rook-ceph.svc.cluster.local
-      access_key_id: ${`${AWS_ACCESS_KEY_ID}`}
-      secret_access_key: ${`${AWS_SECRET_ACCESS_KEY}`}
       region: o11y
       s3ForcePathStyle: true
     bucketNames:


### PR DESCRIPTION
keys definitions are not needed since loki can pull the keys using its internal aws sdk upon definition in global vars