### PR TITLE
(loki) increase chunks cache memory limit to 2Gi

### DIFF
--- a/fleet/lib/loki/values.yaml
+++ b/fleet/lib/loki/values.yaml
@@ -158,7 +158,7 @@ chunksCache:
   replicas: 3
   resources:
     requests: { cpu: 200m, memory: 256Mi }
-    limits: { cpu: 1, memory: 1Gi }
+    limits: { cpu: 1, memory: 2Gi }
 
 # needed by helm
 read:


### PR DESCRIPTION
The chunks cache pods are being killed many times per day for hitting the memory limit. The limit is being doubled from 1Gi -> 2Gi. It may need to be further increased if the pods continue to be OOMKilled.

    State:          Running
      Started:      Fri, 16 Jan 2026 07:21:54 -0700
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Fri, 16 Jan 2026 03:29:44 -0700
      Finished:     Fri, 16 Jan 2026 07:21:53 -0700
    Ready:          True
    Restart Count:  1255
    Limits:
      cpu:     1
      memory:  1Gi
    Requests:
      cpu:      200m
      memory:   256Mi