### PR TITLE
(fleet/fleet-conf) add missing gitrepo for merken (promote #1409 to master)

### DIFF
--- a/fleet/lib/fleet-conf/overlays/cp/gitrepo-merken.yaml
+++ b/fleet/lib/fleet-conf/overlays/cp/gitrepo-merken.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: fleet.cattle.io/v1alpha1
+kind: GitRepo
+metadata:
+  name: merken
+  namespace: fleet-default
+spec:
+  repo: https://github.com/lsst-it/k8s-cookbook
+  branch: cp_production
+  keepResources: true
+  paths:
+    - fleet/s/cp/c/merken/*
+  targets:
+    - name: merken
+      clusterSelector:
+        matchExpressions:
+          - key: management.cattle.io/cluster-display-name
+            operator: In
+            values:
+              - merken
+  correctDrift:
+    enabled: true


### PR DESCRIPTION
<hr>This is an automatic backport of pull request #1409 done by [Mergify](https://mergify.com).