### PR TITLE
(fleet/alloy) add ubiquiti job

### DIFF
--- a/fleet/lib/alloy/overlays/antu/values.yaml
+++ b/fleet/lib/alloy/overlays/antu/values.yaml
@@ -43,6 +43,11 @@ alloy:
       port: 5145
       targetPort: 5145
       protocol: UDP
+    - name: ubiquiti-udp
+      port: 5146
+      targetPort: 5146
+      protocol: UDP
+  stabilityLevel: experimental
   configMap:
     content: |
       logging {
@@ -358,6 +363,17 @@ alloy:
           labels   = { job = "dynalene" }
         }
         relabel_rules = discovery.relabel.syslog.rules
+        forward_to = [loki.write.send.receiver]
+      }
+
+      loki.source.syslog "ubiquiti" {
+        listener {
+          address  = ":5146"
+          syslog_format = "raw"
+          use_incoming_timestamp = false
+          protocol = "udp"
+          labels   = { job = "ubiquiti" }
+        }
         forward_to = [loki.write.send.receiver]
       }
 

--- a/fleet/lib/alloy/overlays/kona/values.yaml
+++ b/fleet/lib/alloy/overlays/kona/values.yaml
@@ -44,6 +44,7 @@ alloy:
       port: 5146
       targetPort: 5146
       protocol: UDP
+  stabilityLevel: experimental
   configMap:
     content: |
       logging {
@@ -365,7 +366,7 @@ alloy:
       loki.source.syslog "ubiquiti" {
         listener {
           address  = ":5146"
-          syslog_format = "rfc3164"
+          syslog_format = "raw"
           use_incoming_timestamp = false
           protocol = "udp"
           labels   = { job = "ubiquiti" }

--- a/fleet/lib/alloy/overlays/kona/values.yaml
+++ b/fleet/lib/alloy/overlays/kona/values.yaml
@@ -365,6 +365,7 @@ alloy:
       loki.source.syslog "ubiquiti" {
         listener {
           address  = ":5146"
+          syslog_format = "rfc3164"
           use_incoming_timestamp = false
           protocol = "udp"
           labels   = { job = "ubiquiti" }

--- a/fleet/lib/alloy/overlays/kona/values.yaml
+++ b/fleet/lib/alloy/overlays/kona/values.yaml
@@ -370,7 +370,7 @@ alloy:
           labels   = { job = "ubiquiti" }
         }
         forward_to = [loki.write.send.receiver]
-      }      
+      }
 
       loki.write "send" {
         endpoint {

--- a/fleet/lib/alloy/overlays/kona/values.yaml
+++ b/fleet/lib/alloy/overlays/kona/values.yaml
@@ -40,6 +40,10 @@ alloy:
       port: 5145
       targetPort: 5145
       protocol: UDP
+    - name: ubiquiti-udp
+      port: 5146
+      targetPort: 5146
+      protocol: UDP
   configMap:
     content: |
       logging {
@@ -357,6 +361,16 @@ alloy:
         relabel_rules = discovery.relabel.syslog.rules
         forward_to = [loki.write.send.receiver]
       }
+
+      loki.source.syslog "ubiquiti" {
+        listener {
+          address  = ":5146"
+          use_incoming_timestamp = false
+          protocol = "udp"
+          labels   = { job = "ubiquiti" }
+        }
+        forward_to = [loki.write.send.receiver]
+      }      
 
       loki.write "send" {
         endpoint {

--- a/fleet/lib/alloy/overlays/merken/values.yaml
+++ b/fleet/lib/alloy/overlays/merken/values.yaml
@@ -40,6 +40,11 @@ alloy:
       port: 5145
       targetPort: 5145
       protocol: UDP
+    - name: ubiquiti-udp
+      port: 5146
+      targetPort: 5146
+      protocol: UDP
+  stabilityLevel: experimental
   configMap:
     content: |
       logging {
@@ -355,6 +360,17 @@ alloy:
           labels   = { job = "dynalene" }
         }
         relabel_rules = discovery.relabel.syslog.rules
+        forward_to = [loki.write.send.receiver]
+      }
+
+      loki.source.syslog "ubiquiti" {
+        listener {
+          address  = ":5146"
+          syslog_format = "raw"
+          use_incoming_timestamp = false
+          protocol = "udp"
+          labels   = { job = "ubiquiti" }
+        }
         forward_to = [loki.write.send.receiver]
       }
 


### PR DESCRIPTION
New features:

- Adds job for ubiquiti devices (efg,wifi, and nvr)
- Logs are stored as raw to support CEF format of ubiquiti. No extensive labeling is needed because fields are easy to query.
- Deployment is set to experimental to support the raw format. 