### PR TITLE
(fleet/loki) reduce retention period of dev

### DIFF
--- a/fleet/lib/loki/overlays/dev/values.yaml
+++ b/fleet/lib/loki/overlays/dev/values.yaml
@@ -21,4 +21,5 @@ gateway:
           - loki.${ get .ClusterLabels "management.cattle.io/cluster-display-name" }.${ .ClusterLabels.site }.lsst.org
 loki:
   limits_config:
-    retention_period: 10d
+    retention_period: 3d
+    max_query_lookback: 3d


### PR DESCRIPTION
Reduces retention period of loki to 3 days and limits the query lookback

This is only for dev, prod keeps 90d retention<hr>This is an automatic backport of pull request #1444 done by [Mergify](https://mergify.com).