### PR TITLE
Update Helm release extended-ceph-exporter to v1.9.2

### DIFF
--- a/fleet/lib/extended-ceph-exporter/fleet.yaml
+++ b/fleet/lib/extended-ceph-exporter/fleet.yaml
@@ -8,7 +8,7 @@ helm:
   chart: *name
   releaseName: *name
   repo: https://galexrt.github.io/extended-ceph-exporter
-  version: 1.8.0
+  version: 1.9.2
   waitForJobs: true
   values:
     serviceMonitor:


### PR DESCRIPTION
(cherry picked from commit d9886689614903894421a25f1496e8d7c607af48)