### PR TITLE
(*) rm extended-ceph-exporter from clusters without rgw running

### DIFF
--- a/fleet/s/cp/c/yagan/extended-ceph-exporter
+++ b/fleet/s/cp/c/yagan/extended-ceph-exporter
@@ -1,1 +1,0 @@
-../../../../lib/extended-ceph-exporter

--- a/fleet/s/cp/c/yepun/extended-ceph-exporter
+++ b/fleet/s/cp/c/yepun/extended-ceph-exporter
@@ -1,1 +1,0 @@
-../../../../lib/extended-ceph-exporter

--- a/fleet/s/ls/c/luan/extended-ceph-exporter
+++ b/fleet/s/ls/c/luan/extended-ceph-exporter
@@ -1,1 +1,0 @@
-../../../../lib/extended-ceph-exporter

--- a/fleet/s/ls/c/manke/extended-ceph-exporter
+++ b/fleet/s/ls/c/manke/extended-ceph-exporter
@@ -1,1 +1,0 @@
-../../../../lib/extended-ceph-exporter


### PR DESCRIPTION
<hr>This is an automatic backport of pull request #1518 done by [Mergify](https://mergify.com).