### PR TITLE
(fleet/rook-ceph-conf) add subchart machi

### DIFF
--- a/fleet/lib/rook-ceph-conf/values.yaml
+++ b/fleet/lib/rook-ceph-conf/values.yaml
@@ -30,3 +30,5 @@ subchart:
     enabled: false
   merken:
     enabled: false
+  machi:
+    enabled: false


### PR DESCRIPTION
Adds missing subchart to machi.<hr>This is an automatic backport of pull request #1526 done by [Mergify](https://mergify.com).