### PR TITLE
(fleet/rook-ceph-conf) add subchart machi

### DIFF
--- a/fleet/lib/rook-ceph-conf/values.yaml
+++ b/fleet/lib/rook-ceph-conf/values.yaml
@@ -30,3 +30,5 @@ subchart:
     enabled: false
   merken:
     enabled: false
+  machi:
+    enabled: false


### PR DESCRIPTION
(cherry picked from commit 93ddcdde937e39048bdf4467f0389d63b50e621d)