### PR TITLE
(fleet/rook-ceph-conf) bump lfa rgw limits

### DIFF
--- a/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-lfa.yaml
+++ b/fleet/lib/rook-ceph-conf/charts/konkong/templates/cephobjectstore-lfa.yaml
@@ -36,7 +36,7 @@ spec:
     resources:
       limits:
         cpu: "16"
-        memory: 4Gi
+        memory: 8Gi
       requests:
         cpu: "1"
         memory: 4Gi


### PR DESCRIPTION
This addresses OOM on pods that are part of the rgw-lfa-a deployment on konkong. 