### PR TITLE
(fleet/k8up-post) adjust prune values

### DIFF
--- a/fleet/lib/k8up-post/overlays/manke/backup-daily.yaml
+++ b/fleet/lib/k8up-post/overlays/manke/backup-daily.yaml
@@ -15,9 +15,12 @@ spec:
     failedJobsHistoryLimit: 2
     successfulJobsHistoryLimit: 2
   prune:
-    schedule: 0 1 * * 0
+    schedule: 0 1 * * * # every day at 1am
     retention:
-      keepLast: 10
+      keepDaily: 7   # 1 snapshot per day for last 7 days
+      keepWeekly: 4  # 1 snapshot per week for last 4 weeks
+      keepMonthly: 3 # 1 snapshot per month for last 3 months
+
   backend:
     repoPasswordSecretRef:
       name: k8up-s3-credentials


### PR DESCRIPTION
The S3 bucket (manke-k8up) filled up due to insufficient prune settings. With 7 PVCs backing up daily, the previous configuration of keepLast: 10 with a weekly prune schedule was not keeping up with snapshot accumulation. 

This keeps 14 snapshots per PVC instead of 10 across everything.
