### PR TITLE
(fleet/loki) reduce ingester replicas for dev

### DIFF
--- a/fleet/lib/loki/overlays/dev/values.yaml
+++ b/fleet/lib/loki/overlays/dev/values.yaml
@@ -23,3 +23,6 @@ loki:
   limits_config:
     retention_period: 3d
     max_query_lookback: 3d
+
+ingester:
+  replicas: 4


### PR DESCRIPTION
dev can only hold 1 replica per node, and kona is a 4 nodes cluster.