### PR TITLE
(fleet/rook-ceph-cluster) updates and cleans up unnecessary value 

### DIFF
--- a/fleet/lib/rook-ceph-cluster/overlays/machi/values.yaml
+++ b/fleet/lib/rook-ceph-cluster/overlays/machi/values.yaml
@@ -52,11 +52,9 @@ cephClusterSpec:
     client.rgw.lfa.a:
       rgw_enable_usage_log: "false"
       rgw_enable_lc_threads: "false"  # disable object gc
-      rgw_gc_max_objs: "0"
     client.rgw.lfagc.a:
       rgw_enable_usage_log: "false"
       rgw_enable_lc_threads: "true"  # enable object gc
-      rgw_gc_max_objs: "32"
   resources:
     mgr:
       limits:


### PR DESCRIPTION
Updatea the configuration to what we have on our other clusters.

Error:

:red_circle: [HIGH] machi nodes showing elevated host-level OOM kills (8 each)
   Category : OOM
   Affected : host=[machi01.ls.lsst.org](http://machi01.ls.lsst.org/), host=[machi02.ls.lsst.org](http://machi02.ls.lsst.org/), host=[machi07.ls.lsst.org](http://machi07.ls.lsst.org/), host=[machi13.ls.lsst.org](http://machi13.ls.lsst.org/), host=[machi15.ls.lsst.org](http://machi15.ls.lsst.org/), host=[machi16.ls.lsst.org](http://machi16.ls.lsst.org/), host=[machi17.ls.lsst.org](http://machi17.ls.lsst.org/), host=[machi23.ls.lsst.org](http://machi23.ls.lsst.org/) (worst: 12 OOM kills)
   Detail  : Hosts machi01-machi17 (8 nodes) each show 8 OOM kill events at the host level, with machi23 showing 12. Combined with the rook-ceph restart storm in cluster=machi, this suggests node-level memory pressure is pervasive across the machi fleet, possibly driven by Ceph OSD processes or Kubernetes system components consuming excess memory.
   Action  : Check node memory usage with kubectl top nodes and free -m on each machi host. Identify OOM-killed processes via journalctl -k | grep -i oom. Review Ceph OSD memory targets (osd_memory_target). Consider adding memory to machi nodes or tuning OSD count per node.