### PR TITLE
(fleet/cnpg-cluster-new) adjust new cnpg cluster resources

### DIFF
--- a/fleet/lib/cnpg-cluster-new/overlays/yagan/cluster-cnpg-cluster.yaml
+++ b/fleet/lib/cnpg-cluster-new/overlays/yagan/cluster-cnpg-cluster.yaml
@@ -51,8 +51,8 @@ spec:
 
   resources:
     limits:
-      cpu: "48"
-      memory: 64Gi
+      cpu: "24"
+      memory: 32Gi
     requests:
-      cpu: "48"
-      memory: 64Gi
+      cpu: "24"
+      memory: 32Gi


### PR DESCRIPTION
Shrinks resources temporarily to fit the instance in the cluster that is running parallel with the production instance. Once we confirm everything works, we can retire the current instance and bump the resources once more. 