### PR TITLE
(fleet/cnpg-cluster-new) add backup

### DIFF
--- a/fleet/lib/cnpg-cluster-new/overlays/generic/cronjob-cnpg-backups-yagan.yaml
+++ b/fleet/lib/cnpg-cluster-new/overlays/generic/cronjob-cnpg-backups-yagan.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cnpg-backups-yagan
+spec:
+  concurrencyPolicy: Forbid
+  schedule: 0 12,21 * * *  # 9AM CLT - 6PM CLT
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 172800
+      template:
+        spec:
+          activeDeadlineSeconds: 14400
+          containers:
+            - name: cnpg-backup
+              image: docker.io/lsstit/cnpg-backup:0.6
+              volumeMounts:
+                - name: ephemeral
+                  mountPath: /tmp
+              imagePullPolicy: IfNotPresent
+              envFrom:
+                - secretRef:
+                    name: cnpg-backups-yagan
+              env:
+                - name: HOST
+                  value: cnpg-loadbalancer-cp.cloudnativepg-cp.svc.cluster.local
+          volumes:
+            - name: ephemeral
+              ephemeral:
+                volumeClaimTemplate:
+                  spec:
+                    accessModes: [ReadWriteOnce]
+                    resources:
+                      requests:
+                        storage: 500Gi
+          restartPolicy: OnFailure

--- a/fleet/lib/cnpg-cluster-new/overlays/generic/externalsecret-cnpg-backups-yagan.yaml
+++ b/fleet/lib/cnpg-cluster-new/overlays/generic/externalsecret-cnpg-backups-yagan.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cnpg-backups-yagan
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  data:
+    - secretKey: AWS_ACCESS_KEY_ID
+      remoteRef:
+        key: cnpg-backups-yagan
+        property: username
+    - secretKey: AWS_SECRET_ACCESS_KEY
+      remoteRef:
+        key: cnpg-backups-yagan
+        property: password
+    - secretKey: AWS_ACCESS_BUCKET
+      remoteRef:
+        key: cnpg-backups-yagan
+        property: bucket
+    - secretKey: PGUSER
+      remoteRef:
+        key: cnpg-cluster-superuser
+        property: username
+    - secretKey: PGPASSWORD
+      remoteRef:
+        key: cnpg-cluster-superuser
+        property: password


### PR DESCRIPTION
Enables backups on the newly deployed instance of CNPG at the summit. 